### PR TITLE
#! env doesn't work on Ubuntu 14.04.1 LTS

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -1,4 +1,4 @@
-#! env python
+#!/usr/bin/env python
 #
 # Script to build and install packages into the Steam runtime
 


### PR DESCRIPTION
bash: ./build-runtime.py: env: Defekter Interpreter: Datei oder Verzeichnis nicht gefunden

No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 14.04.1 LTS
Release:    14.04
Codename:   trusty
