### PR TITLE
Fix typo in build script

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -272,7 +272,7 @@ if args.verbose:
 REPO=args.repo
 
 if args.beta:
-	DIST="steam_beta"
+	DIST="scout_beta"
 
 if args.debug:
 	COMPONENT = "debug"


### PR DESCRIPTION
Hard-coded beta repository was misspelled as steam_beta rather than scout_beta.