### PR TITLE
Add .gitattributes file to indicate license files are part of documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-runtime/common-licenses/* linguist-language=Text
+runtime/common-licenses/* linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+runtime/common-licenses/* linguist-language=Text


### PR DESCRIPTION
GitHub's language detection tool ([linguist](https://github.com/github/linguist)) is incorrectly detecting some of the license files as code.

![image](https://user-images.githubusercontent.com/16418643/44624026-3571a080-a896-11e8-8aeb-47961743b738.png)

This PR adds a .gitattributes file that excludes these files from being included in this visualization, [using the methods described in linguist's documentation.](https://github.com/github/linguist#documentation)

Oddly, use of `linguist` on my local machine produces no difference in results with or without this change, and I believe that the language breakdown preview on my fork has yet to be updated, so I cannot see 'live' results.

Here's the output when run locally.

```
$ linguist --version
  Linguist v6.4.1
  Detect language type for a file, or, given a repository, determine language breakdown.

  Usage: linguist <path>
         linguist <path> [--breakdown] [--json]
         linguist [--breakdown] [--json]

$ linguist --breakdown
64.32%  Shell
35.68%  Python

Python:
build-runtime.py

Shell:
runtime/run.sh
runtime/scripts/check-program.sh
runtime/scripts/check-runtime-conflicts.sh
runtime/scripts/check-runtime-consistency.sh
runtime/scripts/check-symlinks.sh
setup_chroot.sh
```