### PR TITLE
Write manifests listing everything in the Runtime/SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,10 @@ packages/binary/
 packages/debug/
 packages/source/
 runtime/amd64/
+runtime/built-using.txt
 runtime/i386/
+runtime/manifest.txt
+runtime/manifest.deb822.gz
 runtime/source/
 publish_symbols.sh
 do-buildbot-build.sh

--- a/setup_chroot.sh
+++ b/setup_chroot.sh
@@ -109,6 +109,10 @@ build_chroot()
 	chmod +x "/tmp/${TMPNAME}"
 	schroot --chroot ${CHROOT_NAME} -d /tmp --user root -- "/tmp/${TMPNAME}" ${BETA_ARG} --configure
 	rm -f "/tmp/${TMPNAME}"
+	cp -f "$SCRIPT_DIR/write-manifest" "/tmp/${TMPNAME}"
+	chmod +x "/tmp/${TMPNAME}"
+	schroot --chroot ${CHROOT_NAME} -d /tmp --user root -- "/tmp/${TMPNAME}" /
+	rm -f "/tmp/${TMPNAME}"
 }
 
 configure_chroot()

--- a/write-manifest
+++ b/write-manifest
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# Copyright © 2016-2017 Simon McVittie
+# Copyright © 2017-2018 Collabora Ltd.
+#
+# SPDX-License-Identifier: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+set -e
+set -u
+set -x
+set -o pipefail
+
+me="$(basename "$0")"
+
+usage () {
+    local status="${1-2}"
+
+    if [ "$status" -ne 0 ]; then
+        exec >&2
+    fi
+
+    echo "$me: Usage"
+    echo "    $me SYSROOT"
+    echo
+    echo "Run this script as root."
+    exit "$status"
+}
+
+getopt_temp="$(getopt -o '' --long \
+    'help' \
+    -n "$me" -- "$@")"
+
+eval set -- "$getopt_temp"
+unset getopt_temp
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        (--help)
+            usage 0
+            # not reached
+            ;;
+
+        (--)
+            shift
+            break
+            ;;
+
+       (-*)
+            echo "$me: unknown option: $1" >&2
+            usage 2
+            # not reached
+            ;;
+
+        (*)
+            break
+            ;;
+    esac
+done
+
+if [ "x$(id -u)" != x0 ] || [ "$#" -ne 1 ]; then
+    usage 2
+    # not reached
+fi
+
+sysroot="$1"
+cd "$sysroot"
+
+in_chroot () {
+    chroot "$sysroot" "$@"
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+exec 3>"$sysroot/usr/manifest.dpkg"
+
+printf '#Package[:Architecture]\t#Version\t#Source\t#Installed-Size\n' >&3
+
+dpkg_version="$(in_chroot dpkg-query -W -f '${Version}' dpkg)"
+
+if in_chroot dpkg --compare-versions "$dpkg_version" ge 1.16.2; then
+    in_chroot dpkg-query -W -f \
+        '${binary:Package}\t${Version}\t${Source}\t${Installed-Size}\n' \
+        | LC_ALL=C sort -u >&3
+else
+    in_chroot dpkg-query -W -f \
+        '${Package}:${Architecture}\t${Version}\t${Source}\t${Installed-Size}\n' \
+        | LC_ALL=C sort -u >&3
+fi
+
+exec 3>"$sysroot/usr/manifest.dpkg.built-using"
+
+printf '#Built-Binary\t#Built-Using-Source\t#Built-Using-Version\n' >&3
+
+in_chroot dpkg-query -W -f '$Package\t${Built-Using}\n' | perl -ne '
+chomp;
+next unless /^\S+\t.+$/;
+my $binary = $1;
+my @using = split /,/, $2;
+next unless @using;
+foreach my $using (@using) {
+    $using =~ s/ //;
+    next unless $using =~ /^(\S+)\(=(\S+)\)$/;
+    print "$binary\t$1\t$2\n";
+}
+' | LC_ALL=C sort -u >&3
+
+# vim:set sw=4 sts=4 et:


### PR DESCRIPTION
This PR adds manifest files to the Runtime and the corresponding SDK chroot listing the source and binary packages that went into the Runtime or SDK, in a tab-separated table that is suitable for machine-processing and also supported by many spreadsheets:

```
#Package[:Architecture]	#Version	#Source	#Installed-Size
dconf-gsettings-backend:amd64	0.12.0-0ubuntu1.1+srt4	d-conf	81
...
libgudev-1.0-0:amd64	1:175-0ubuntu9.2+srt4	udev (175-0ubuntu9.2+srt4)	187
```

The manifest is in a canonical sorting order, so that different runtimes can easily be compared with `diff -u`. Listing the source package (and its version number, if it differs from the binaries) lets us match binary packages to source packages for GPL compliance, and listing the installed size in Kbytes gives us an idea of what the largest contributors to the Runtime's size are.

For the SDK, the manifest also tells us which packages came from SteamRT (`+srt` suffix) and which ones came from Ubuntu (no `+srt`), and can be used to detect discrepancies between the Runtime and SDK (in particular if a Runtime package has been superseded by a newer version from Ubuntu).

For the Runtime (but not the SDK, for which it isn't straightforward to do) I've also included a compressed version of the complete "deb822" package list.

The format is the same as the manifests generated by [flatdeb](https://gitlab.collabora.com/smcv/flatdeb/), which I'm using to experiment with [generating Flatpak runtimes from the Steam Runtime](https://gitlab.collabora.com/smcv/flatdeb-steam/): this lets us compare runtimes made by different methods.