### PR TITLE
tests: Rewrap long lines, fix vim modeline

### DIFF
--- a/tests/all-packages-published.py
+++ b/tests/all-packages-published.py
@@ -53,4 +53,4 @@ if __name__ == '__main__':
 
     sys.exit(1 if fail else 0)
 
-# vi: set noexpandtab:
+# vi: set sw=4 sts=4 et:

--- a/tests/all-packages-published.py
+++ b/tests/all-packages-published.py
@@ -33,10 +33,8 @@ if __name__ == '__main__':
 
                 if line <= last:
                     print(
-                        'warning: '
-                        'sourcepkgs.list:%d: '
-                        'not in `LC_ALL=C sort -u` '
-                        'order near %r'
+                        'warning: sourcepkgs.list:%d: not in '
+                        '`LC_ALL=C sort -u` order near %r'
                         % (i, line),
                         file=sys.stderr)
 
@@ -45,8 +43,8 @@ if __name__ == '__main__':
     if source_pkgs:
         for p in source_pkgs:
             print(
-                'error: source package %s is listed in '
-                'sourcepkgs.list but not in packages.txt'
+                'error: source package %s is listed in sourcepkgs.list '
+                'but not in packages.txt'
                 % p,
                 file=sys.stderr)
             fail = True


### PR DESCRIPTION
This follows up from @TTimo's replacement of the hard tabs ("noexpandtab" in vim terms) with PEP-8's recommended 4-space indentation ("shiftwidth=4 softtabstop=4 expandtab" in vim, or "sw=4 sts=4 et" with conventional abbreviations) in commit d473ed43.

Now that this test is using 4-space indentation, it's also unnecessary to wrap long lines quite so aggressively.