### PR TITLE
Publish src:fcitx in apt repository

### DIFF
--- a/sourcepkgs.list
+++ b/sourcepkgs.list
@@ -30,6 +30,7 @@ e2fsprogs install
 eglibc install
 elfutils install
 expat install
+fcitx install
 findutils install
 flac install
 fltk1.1 install

--- a/tests/all-packages-published.py
+++ b/tests/all-packages-published.py
@@ -43,8 +43,8 @@ if __name__ == '__main__':
     if source_pkgs:
         for p in source_pkgs:
             print(
-                'error: source package %s is listed in sourcepkgs.list '
-                'but not in packages.txt'
+                'error: source package %s is listed in packages.txt '
+                'but not in sourcepkgs.list'
                 % p,
                 file=sys.stderr)
             fail = True


### PR DESCRIPTION
Otherwise fcitx-libs-dev won't necessarily be available to be included in the SDK. This discrepancy was detected by `make check`.

This branch also fixes the sense of the error message that detected it, which confused me at first :-)