### PR TITLE
packages.txt: List libvulkan* as coming from src:vulkan

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -162,7 +162,7 @@ tdb		libtdb1 libtdb-dev
 tiff		libtiff4 libtiff4-dev
 udev		libudev0 libudev-dev libgudev-1.0-0 libgudev-1.0-dev
 util-linux	libuuid1 uuid-dev
-vulkan-loader	libvulkan1 libvulkan-dev
+vulkan		libvulkan1 libvulkan-dev
 x11proto-composite	x11proto-composite-dev
 x11proto-core	x11proto-core-dev
 x11proto-damage	x11proto-damage-dev

--- a/tests/all-packages-published.py
+++ b/tests/all-packages-published.py
@@ -43,8 +43,8 @@ if __name__ == '__main__':
     if source_pkgs:
         for p in source_pkgs:
             print(
-                'error: source package %s is listed in sourcepkgs.list '
-                'but not in packages.txt'
+                'error: source package %s is listed in packages.txt '
+                'but not in sourcepkgs.list'
                 % p,
                 file=sys.stderr)
             fail = True


### PR DESCRIPTION
libvulkan{1,-dev} 1.0.x were built by src:vulkan-loader, but the current version 1.1.73 is from a renamed source package, src:vulkan.
    
Detected by `make check`.

This also includes the same commit as #109 to fix the error message that detected this discrepancy.