### PR TITLE
Fix steam-runtime dockerfile for Docker 1.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ merge_hg_to_runtime.sh
 x-tools
 tmp/
 newpkg/
+ubuntu-precise-core-cloudimg-*

--- a/steam-runtime.docker
+++ b/steam-runtime.docker
@@ -5,8 +5,8 @@
 # extra_bootstrap  - Extra script file to include out of scripts/ and execute to bootstrap the container (out of /root).
 #                    e.g. --build-arg=extra_bootstrap=bootstrap-custom.sh
 # proxy            - optional argument for http/https proxy
-ARG arch=amd64
 FROM scratch
+ARG arch=amd64
 ARG beta
 ARG arch
 ARG extra_bootstrap
@@ -65,7 +65,12 @@ RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list
 RUN mkdir -p /run/systemd && echo 'docker' > /run/systemd/container
 
 # Allow resolvconf to be installed without error
-RUN echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections
+RUN apt-get -y install debconf-utils \
+	&& echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections \
+	&& apt-get -y install resolvconf
+
+# Prevent failure during installation of 'time'
+RUN apt-get -y install install-info
 
 ##
 ## Steam Runtime specific setup


### PR DESCRIPTION
Following corrections were needed:

Reordering lines ARG and FROM prevents docker from failing with error:

    Step 1/18 : ARG arch=amd64
    Please provide a source image with `from` prior to commit

Additional package installation to prevent `resolvconf` from failing with message about no symlink.

Additional package installation of `install-info` to prevent post-installation step of `time` from stopping whole image creation.

Also, the `.gitignore` file was updated to prevent accidental commit of generated image files.

These changes enable the creation of images on Fedora, CentOS, RHEL and presumably any other distro using Docker 1.1x. Without this, I cannot follow steps to build Proton on my machine.