### PR TITLE
Fix library mismatches when LD_LIBRARY_CONFIG has an expansion string in it

### DIFF
--- a/runtime/run.sh
+++ b/runtime/run.sh
@@ -27,7 +27,11 @@ if [ "${STEAM_RUNTIME_PREFER_HOST_LIBRARIES-}" != "0" ]; then
 	
 			host_library_paths=$host_library_paths$library_path_prefix:
 		fi
-	done <<< "$(/sbin/ldconfig -XNv 2> /dev/null)"
+	# There's a bug where if LD_LIBRARY_PATH contains one of the expansion
+	# tokens ($LIB, $ORIGIN, etc), or any prefix of one, then ldconfig
+	# segfaults without printing anything. To avoid that, clear LD_LIBRARY_PATH
+	# when running ldconfig.
+	done <<< "$(LD_LIBRARY_PATH= /sbin/ldconfig -XNv 2> /dev/null)"
 	
 	host_library_paths="$STEAM_RUNTIME/pinned_libs_32:$STEAM_RUNTIME/pinned_libs_64:$host_library_paths"
 fi


### PR DESCRIPTION
I came across this when running Steam through primusrun on Arch and Manjaro.

On Arch, the primusrun script works by setting LD_LIBRARY_PATH to /usr/$LIB/primus. As it turns out, though, there's a bug where if you LD_LIBRARY_PATH contains $LIB, $ORIGIN, $PLATFORM, or even any prefix of them, then ldconfig segfaults.

The steam runtime script tries to run ldconfig to figure out what the normal library search paths are. When ldconfig crashes without any output, it doesn't find any paths, so it ends up setting LD_LIBRARY_PATH to point only to the libraries that steam provides.

It's downhill after that: Primus can't load because it has the wrong version of libstdc++. Mesa can't load because it has the wrong version of XCB. I've even seen reports of grep failing within the rest of the steam startup scripts because it has the wrong version of libpcre.

Anyway, as far as I can tell, just clearing LD_LIBRARY_PATH when it runs ldconfig is enough to avoid the problem, and for just finding the system library paths, it probably doesn't need to worry about the previous value of LD_LIBRARY_PATH.

The main steam.sh script might also need a similar fix in pin_newer_runtime_libs().