### PR TITLE
build-runtime: Add pyflakes and pycodestyle checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all:
 check:
 	@set -e; \
 	e=0; \
-	for t in tests/*.py; do \
+	for t in tests/*.py tests/*.sh; do \
 		echo "$$t..."; \
 		if $$t; then \
 			echo "$$t: PASS"; \

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -13,14 +13,14 @@ from debian import deb822
 import argparse
 
 try:
-    from io import BytesIO
+	from io import BytesIO
 except ImportError:
-    from cStringIO import StringIO as BytesIO
+	from cStringIO import StringIO as BytesIO
 
 try:
-    from urllib.request import (urlopen, urlretrieve)
+	from urllib.request import (urlopen, urlretrieve)
 except ImportError:
-    from urllib import (urlopen, urlretrieve)
+	from urllib import (urlopen, urlretrieve)
 
 destdir="newpkg"
 arches=["amd64", "i386"]

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -13,7 +13,7 @@ from debian import deb822
 import argparse
 
 try:
-    from io import BufferedReader, BytesIO
+    from io import BytesIO
 except ImportError:
     from cStringIO import StringIO as BytesIO
 

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -110,7 +110,7 @@ def install_sources (sourcelist):
 			ver = stanza['files'][0]['name'].split('-')[0]
 			p = subprocess.Popen(["dpkg-source", "-x", "--no-copy", dsc_file, os.path.join(dest_dir,ver)], stdout=subprocess.PIPE, universal_newlines=True)
 			for line in iter(p.stdout.readline, ""):
-				if args.verbose or re.match('dpkg-source: warning: ',line):
+				if args.verbose or re.match(r'dpkg-source: warning: ',line):
 					print(line, end='')
 
 	if skipped > 0:
@@ -222,7 +222,7 @@ def install_symbols (binarylist, manifest):
 		url_file_handle = BytesIO(urlopen(packages_url).read())
 		for stanza in deb822.Packages.iter_paragraphs(url_file_handle):
 			p = stanza['Package']
-			m = re.match('([\w\-\.]+)\-dbgsym', p)
+			m = re.match(r'([\w\-\.]+)\-dbgsym', p)
 			if m and m.group(1) in binarylist:
 				manifest.append(Binary(stanza))
 				if args.verbose:
@@ -282,7 +282,7 @@ def fix_debuglinks ():
 				#
 				p = subprocess.Popen(["readelf", '-n', os.path.join(dir,file)], stdout=subprocess.PIPE, universal_newlines=True)
 				for line in iter(p.stdout.readline, ""):
-					m = re.search('Build ID: (\w{2})(\w+)',line)
+					m = re.search(r'Build ID: (\w{2})(\w+)',line)
 					if m:
 						linkdir = os.path.join(args.runtime,arch,"usr/lib/debug/.build-id",m.group(1))
 						if not os.access(linkdir, os.W_OK):

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -67,7 +67,7 @@ def install_sources (sourcelist):
 	sources_url = "%s/dists/%s/%s/source/Sources.gz" % (REPO, DIST, COMPONENT)
 	print("Downloading sources from %s" % sources_url)
 	sz = urlopen(sources_url)
-	url_file_handle=BytesIO( sz.read() )
+	url_file_handle=BytesIO(sz.read())
 	sources = gzip.GzipFile(fileobj=url_file_handle)
 
 	skipped = 0
@@ -190,9 +190,9 @@ def install_deb (basename, deb, dest_dir):
 	#
 	# Write the tag file and checksum to the 'installed' subdirectory
 	#
-	with open(os.path.join(installtag_dir,basename),"w") as f:
+	with open(os.path.join(installtag_dir, basename), "w") as f:
 		subprocess.check_call(['dpkg-deb', '-c', deb], stdout=f)
-	with open(os.path.join(installtag_dir,basename+".md5"),"w") as f:
+	with open(os.path.join(installtag_dir, basename + ".md5"), "w") as f:
 		os.chdir(os.path.dirname(deb))
 		subprocess.check_call(['md5sum', os.path.basename(deb)], stdout=f)
 

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -53,7 +53,7 @@ def download_file(file_url, file_path):
 	try:
 		if os.path.getsize(file_path) > 0:
 			return False
-	except:
+	except OSError:
 		pass
 
 	urlretrieve(file_url, file_path)

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -32,8 +32,10 @@ COMPONENT="main"
 # The top level directory
 top = sys.path[0]
 
+
 def str2bool (b):
 	return b.lower() in ("yes", "true", "t", "1")
+
 
 def parse_args():
 	parser = argparse.ArgumentParser()
@@ -46,6 +48,7 @@ def parse_args():
 	parser.add_argument("-v", "--verbose", help="verbose", action="store_true")
 	return parser.parse_args()
 
+
 def download_file(file_url, file_path):
 	try:
 		if os.path.getsize(file_path) > 0:
@@ -55,6 +58,7 @@ def download_file(file_url, file_path):
 
 	urlretrieve(file_url, file_path)
 	return True
+
 
 def install_sources (sourcelist):
 	#
@@ -178,7 +182,6 @@ def install_binaries (binarylist, manifest):
 		print("Skipped downloading %i file(s) that were already present." % skipped)
 
 
-
 def install_deb (basename, deb, dest_dir):
 	installtag_dir=os.path.join(dest_dir, "installed")
 	if not os.access(installtag_dir, os.W_OK):
@@ -239,7 +242,7 @@ def install_symbols (binarylist, manifest):
 	if skipped > 0:
 		print("Skipped downloading %i symbol deb(s) that were already present." % skipped)
 
-#
+
 # Walks through the files in the runtime directory and converts any absolute symlinks
 # to their relative equivalent
 #
@@ -262,7 +265,7 @@ def fix_symlinks ():
 						os.unlink(filepath)
 						os.symlink(os.path.relpath(target2,dir), filepath)
 
-#
+
 # Creates the usr/lib/debug/.build-id/xx/xxxxxxxxx.debug symlink tree for all the debug
 # symbols
 #

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -68,7 +68,7 @@ def install_sources (sourcelist):
 	print("Downloading sources from %s" % sources_url)
 	sz = urlopen(sources_url)
 	url_file_handle=BytesIO( sz.read() )
-	sources = gzip.GzipFile(fileobj=url_file_handle);
+	sources = gzip.GzipFile(fileobj=url_file_handle)
 
 	skipped = 0
 	#
@@ -104,8 +104,8 @@ def install_sources (sourcelist):
 			#
 			dest_dir=os.path.join(args.runtime,"source",p)
 			if os.access(dest_dir, os.W_OK):
-				shutil.rmtree(dest_dir);
-			os.makedirs(dest_dir);
+				shutil.rmtree(dest_dir)
+			os.makedirs(dest_dir)
 			dsc_file = os.path.join(dir,stanza['files'][0]['name'])
 			ver = stanza['files'][0]['name'].split('-')[0]
 			p = subprocess.Popen(["dpkg-source", "-x", "--no-copy", dsc_file, os.path.join(dest_dir,ver)], stdout=subprocess.PIPE, universal_newlines=True)

--- a/tests/pycodestyle.sh
+++ b/tests/pycodestyle.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Copyright © 2016-2018 Simon McVittie
+# Copyright © 2018 Collabora Ltd.
+#
+# SPDX-License-Identifier: MIT
+# (See build-runtime.py)
+
+set -e
+set -u
+
+if [ "x${PYCODESTYLE:=pycodestyle}" = xfalse ] || \
+        [ -z "$(command -v "$PYCODESTYLE")" ]; then
+    echo "1..0 # SKIP pycodestyle not found"
+    exit 0
+fi
+
+echo "1..2"
+
+if "${PYCODESTYLE}" \
+    --ignore=W191,E211,E225,E231,E501 \
+    build-runtime.py \
+    >&2; then
+    echo "ok 1 - $PYCODESTYLE reported no issues"
+else
+    echo "not ok 1 # TODO $PYCODESTYLE issues reported"
+fi
+
+if "${PYCODESTYLE}" \
+    tests/*.py \
+    >&2; then
+    echo "ok 2 - $PYCODESTYLE reported no issues"
+else
+    echo "not ok 2 # TODO $PYCODESTYLE issues reported"
+fi
+
+# vim:set sw=4 sts=4 et:

--- a/tests/pyflakes.sh
+++ b/tests/pyflakes.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Copyright © 2016-2018 Simon McVittie
+# Copyright © 2018 Collabora Ltd.
+#
+# SPDX-License-Identifier: MIT
+# (See build-runtime.py)
+
+set -e
+set -u
+
+if [ "x${PYFLAKES:=pyflakes3}" = xfalse ] || \
+        [ -z "$(command -v "$PYFLAKES")" ]; then
+    echo "1..0 # SKIP pyflakes3 not found"
+elif "${PYFLAKES}" \
+    *.py \
+    tests/*.py \
+    >&2; then
+    echo "1..1"
+    echo "ok 1 - $PYFLAKES reported no issues"
+else
+    echo "1..1"
+    echo "not ok 1 # TODO $PYFLAKES issues reported"
+fi
+
+# vim:set sw=4 sts=4 et:


### PR DESCRIPTION
pyflakes and (to a lesser extent) pycodestyle can often act as an early-warning system for bugs.

This branch adds pyflakes and pycodestyle checks in `make check`, and fixes a non-intrusive subset of pycodestyle warnings for `build-runtime.py`.