### PR TITLE
Mark schroot tarballs as unofficial by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ newpkg/
 /unofficial-steam-runtime-*.manifest.txt
 /unofficial-steam-runtime-*.sources.txt
 /unofficial-steam-runtime-*.tar.xz
+/unofficial-steam-runtime-sdk-chroot-*.deb822.gz
+/unofficial-steam-runtime-sdk-chroot-*.tar.gz
+/unofficial-steam-runtime-sdk-chroot-*.txt

--- a/debos-chroot.yaml
+++ b/debos-chroot.yaml
@@ -6,7 +6,9 @@
 {{- $suite := or .suite "scout_beta" -}}
 {{- $mirror := or .mirror "http://repo.steamstatic.com/steamrt" -}}
 {{- $version := or .version "0" -}}
-{{- $basename := or .basename (printf "steam-runtime-sdk-chroot-%s_%s_%s" $suite $version $architecture) -}}
+{{- /* More readably: .official ? "" : "unofficial-" */ -}}
+{{- $basename_prefix := or (and (not .official) "unofficial-") ("") -}}
+{{- $basename := or .basename (printf "%ssteam-runtime-sdk-chroot-%s_%s_%s" $basename_prefix $suite $version $architecture) -}}
 {{- $tarball := or .tarball (printf "%s.tar.gz" $basename) -}}
 
 architecture: {{ $architecture }}


### PR DESCRIPTION
This matches the behaviour of the runtime tarballs.. Use "debos -t official:yes ..." to get an official tarball.