### PR TITLE
Fix runtime prefix naming for non-beta, non-scout apt suites

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -428,7 +428,7 @@ else:
 	if DIST == 'scout_beta':
 		name = '%s-beta' % name
 	elif DIST != 'scout':
-		name = '%s-%s' % DIST
+		name = '%s-%s' % (name, DIST)
 
 	if args.symbols:
 		name += '-sym'


### PR DESCRIPTION
For example, "./build-runtime.py ... --suite=scout-misc-backports"
was intended to produce
unofficial-steam-runtime-scout-misc-backports-release_20181106.tar.xz.
Without this fix, it would just crash.