### PR TITLE
build-runtime.py: Optionally split runtime into parts

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -32,6 +32,10 @@ arches=["amd64", "i386"]
 # The top level directory
 top = sys.path[0]
 
+ONE_MEGABYTE = 1024 * 1024
+SPLIT_MEGABYTES = 50
+MIN_PARTS = 3
+
 
 def str2bool (b):
 	return b.lower() in ("yes", "true", "t", "1")
@@ -137,7 +141,16 @@ def parse_args():
 	parser.add_argument(
 		'--strict', action="store_true",
 		help='Exit unsuccessfully when something seems wrong')
-	return parser.parse_args()
+	parser.add_argument(
+		'--split', default=None,
+		help='Also generate an archive split into 50M parts')
+
+	args = parser.parse_args()
+
+	if args.split is not None and args.archive is None:
+		parser.error('--split requires --archive')
+
+	return args
 
 
 def download_file(file_url, file_path):
@@ -887,5 +900,48 @@ if args.archive is not None:
 		os.symlink(
 			os.path.basename(archive) + '.checksum',
 			symlink + '.checksum')
+
+	if args.split:
+		with open(archive, 'rb') as archive_reader:
+			part = 0
+			position = 0
+			part_writer = open(args.split + ext + '.part0', 'wb')
+
+			while True:
+				blob = archive_reader.read(ONE_MEGABYTE)
+
+				if not blob:
+					break
+
+				if position >= SPLIT_MEGABYTES:
+					part += 1
+					position -= SPLIT_MEGABYTES
+					part_writer.close()
+					part_writer = open(
+						'%s%s.part%d' % (
+							args.split, ext, part
+						),
+						'wb')
+
+				part_writer.write(blob)
+				position += 1
+
+			while part < MIN_PARTS - 1:
+				part += 1
+				part_writer.close()
+				part_writer = open(
+					'%s%s.part%d' % (
+						args.split, ext, part
+					),
+					'wb')
+
+			part_writer.close()
+
+		with open(args.split + '.checksum', 'w') as writer:
+			writer.write('%s  %s%s\n' % (
+				archive_md5.hexdigest(),
+				os.path.basename(args.split),
+				ext,
+			))
 
 # vi: set noexpandtab:

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import gzip
+import hashlib
 import shutil
 import subprocess
 import time
@@ -802,15 +803,21 @@ if args.archive is not None:
 	subprocess.check_call(cmd)
 
 	print("Creating archive checksum %s.checksum..." % archive)
+	archive_md5 = hashlib.md5()
+
+	with open(archive, 'rb') as archive_reader:
+		while True:
+			blob = archive_reader.read(ONE_MEGABYTE)
+
+			if not blob:
+				break
+
+			archive_md5.update(blob)
+
 	with open(archive + '.checksum', 'w') as writer:
-		subprocess.check_call(
-			[
-				'md5sum',
-				os.path.basename(archive),
-			],
-			cwd=os.path.dirname(archive),
-			stdout=writer,
-		)
+		writer.write('%s  %s\n' % (
+			archive_md5.hexdigest(), os.path.basename(archive)
+		))
 
 	if archive_dir is not None:
 		print("Copying manifest files to %s..." % archive_dir)

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -133,6 +133,9 @@ def parse_args():
 		"--compression", help="set compression [xz|gx|bz2|none]",
 		choices=('xz', 'gz', 'bz2', 'none'),
 		default='xz')
+	parser.add_argument(
+		'--strict', action="store_true",
+		help='Exit unsuccessfully when something seems wrong')
 	return parser.parse_args()
 
 
@@ -375,6 +378,9 @@ def install_binaries(binaries_by_arch, binarylist, manifest):
 			#
 			e = "ERROR: Package %s not found in Packages files\n" % p
 			sys.stderr.write(e)
+
+		if installset and args.strict:
+			raise SystemExit('Not all binary packages were found')
 
 	if skipped > 0:
 		print("Skipped downloading %i file(s) that were already present." % skipped)


### PR DESCRIPTION
This matches the format in which it gets delivered by the Steam client. Recent Runtime versions are a little smaller than they have historically been, so we need to make sure to create .part2 (even if it's empty) to avoid this failure mode:
    
* Steam user has an older Runtime (parts 0 to 2 are non-empty)
* client updates to a newer Runtime (parts 0 to 1)
* `cat steam-runtime.tar.xz.part* > steam-runtime.tar.xz`
* now steam-runtime.tar.xz contains parts 0 to 1 of the new runtime
  and part 2 of the old runtime, and is a corrupt archive

---

This branch currently depends on and includes #128, but it could be rebased to avoid that if #128 is problematic for some reason.