### PR TITLE
build-runtime.py: Require that runtime doesn't exist and templates does

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -157,6 +157,17 @@ def parse_args():
 	if args.split is not None and args.archive is None:
 		parser.error('--split requires --archive')
 
+	if not os.path.isdir(args.templates):
+		parser.error(
+			'Argument to --templates, %r, must be a directory'
+			% args.templates)
+
+	# os.path.exists is false for dangling symlinks, so check for both
+	if os.path.exists(args.runtime) or os.path.islink(args.runtime):
+		parser.error(
+			'Argument to --runtime, %r, must not already exist'
+			% args.runtime)
+
 	return args
 
 
@@ -764,9 +775,8 @@ else:
 
 name_version = '%s_%s' % (name, version)
 
-# Populate runtime from template if necessary
-if not os.path.exists(args.runtime):
-	shutil.copytree(args.templates, args.runtime, symlinks=True)
+# Populate runtime from template
+shutil.copytree(args.templates, args.runtime, symlinks=True)
 
 with open(os.path.join(args.runtime, 'version.txt'), 'w') as writer:
 	writer.write('%s\n' % name_version)


### PR DESCRIPTION
If files in ./templates (or the argument to --templates if different)
are changed or added, while reusing an existing ./runtime (or the
argument to --runtime if different), then we would unexpectedly fail to
update those files. For example, after fixing a bug in run.sh, we
wouldn't pick up the fixed version in the runtime until we either use
a different target directory or delete and recreate ./runtime.

Similarly, if files in ./templates are removed, their counterparts in
./runtime would stay until we either switch to a different target
directory or delete ./runtime.

If we require the caller to give us a nonexistent target directory, it
becomes completely clear what is going on, and makes the caller
responsible for doing the right thing (either using a different target
directory for each build, deleting unwanted old builds, or moving
unwanted old builds out of the way).

While we're here, also validate that ./templates exists: if it didn't,
our call to shutil.copytree() would just have crashed anyway, but we
might as well have a nicer error message in the common case.