### PR TITLE
Fix packages.txt, sourcepkgs.list for inclusion of new SDL's dependencies

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -134,7 +134,7 @@ libxt		libxt6 libxt-dev
 libxtst		libxtst6 libxtst-dev
 libxxf86vm	libxxf86vm1 libxxf86vm-dev
 mesa		libglu1-mesa libglu1-mesa-dev
-mpg123		mpg123 mpg123-dev
+mpg123		libmpg123-0 libmpg123-dev
 ncurses		libncurses5 libncurses5-dev libncursesw5 libncursesw5-dev libtinfo5 libtinfo-dev
 network-manager	network-manager-dev libnm-util2 libnm-util-dev libnm-glib4 libnm-glib-dev
 nspr		libnspr4 libnspr4-dev

--- a/sourcepkgs.list
+++ b/sourcepkgs.list
@@ -133,6 +133,7 @@ mawk install
 mesa install
 mpclib3 install
 mpfr4 install
+mpg123 install
 ncurses install
 network-manager install
 nspr install
@@ -141,6 +142,8 @@ nvidia-cg-toolkit install
 openal-soft install
 openldap install
 openssl install
+opus install
+opusfile install
 orc install
 p11-kit install
 pam install

--- a/sourcepkgs.list
+++ b/sourcepkgs.list
@@ -41,6 +41,7 @@ gcc-4.6 install
 gcc-4.8 install
 gcc-5 install
 gconf install
+gdb install
 gdk-pixbuf install
 glew install
 glew1.6 install


### PR DESCRIPTION
packages: Include libmpg123 shared libraries, not mpg123 executable

It's important that we distinguish between source packages (the first column of this file) and binary packages (every other column).

libsdl2-mixer dlopens libmpg123.so.0 to play MP3 audio, so we want that in the Runtime, otherwise games that use SDL for MP3 audio won't work unless the host system happens to have libmpg123-0 (or equivalent) installed on it.

We don't want /usr/bin/mpg123, the command-line MP3 player, which is useless without libmpg123.

Similarly, we presumably want development runtimes to have libmpg123-dev, the development headers for this MP3 playback library, rather than the nonexistent mpg123-dev.

I've assumed that we don't need libout123, which appears to be an audio output abstraction layer analogous to SDL2 or PortAudio, used by the mpg123 command-line MP3 player.

---

sourcepkgs: Update from live infrastructure
    
The libsdl2-mixer in scout_beta requires libraries from mpg123, opus and opusfile. These were listed in packages.txt but not in sourcepkgs.list, causing `make check` to fail.

sourcepkgs.list is the list of source packages to be included in the apt repository for the runtime, and this change has already been deployed on the live Steam Runtime infrastructure <http://repo.steampowered.com/steamrt/conf/sourcepkgs.list>.

---

sourcepkgs: Include gdb in the apt repository

gdb isn't included in the Steam Runtime, but it's helpful for developers to be able to install it in a chroot or Docker image.

---

cc @TTimo @slouken