### PR TITLE
build-runtime: Rename --runtime to --output, and take away the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,35 @@ Testing or shipping with the runtime
 
 Steam ships with a copy of the Steam Runtime and all Steam Applications are launched within the runtime environment. For some scenarios, you may want to test an application with a different build of the runtime. You can use the **build-runtime.py** script to download various flavors of the runtime.
 
-    usage: build-runtime.py [-h] [-r RUNTIME] [-b] [-d] [--source] [--symbols]
-                            [--repo REPO] [-v]
-    
-    optional arguments:
-      -h, --help            show this help message and exit
-      -r RUNTIME, --runtime RUNTIME
-                            specify runtime path
-      -b, --beta            build beta runtime
-      -d, --debug           build debug runtime
-      --source              include sources
-      --symbols             include debugging symbols
-      --repo REPO           source repository
-      -v, --verbose         verbose
-    
-Once the runtime is downloaded, you can use the **run.sh** script to launch any program within that runtime environment. 
+To get a Steam Runtime in a directory, run a command like:
+
+    ./build-runtime.py --output=$(pwd)/runtime
+
+The resulting directory is similar to the `ubuntu12_32/steam-runtime`
+directory in a Steam installation.
+
+To get a Steam Runtime in a compressed tar archive for easy transfer to
+other systems, similar to the official runtime deployed with the
+Steam client, use a command like:
+
+    ./build-runtime.py --archive=$(pwd)/steam-runtime.tar.xz
+
+or to output a tarball and metadata files with automatically-generated
+names in a directory, specify the name of an existing directory, or a
+directory to be created with a `/` suffix:
+
+    ./build-runtime.py --archive=$(pwd)/archives/
+
+The archive will unpack into a directory named `steam-runtime`.
+
+The `--archive` and `--output` options can be combined, but at least one
+is required.
+
+Run `./build-runtime.py --help` for more options.
+
+Once the runtime is downloaded (and unpacked into a directory, if you used
+an archive), you can use the **run.sh** script to launch any program
+within that runtime environment.
 
 To launch Steam itself (and any Steam applications) within your runtime, set the STEAM_RUNTIME environment variable to point to your runtime directory;
 


### PR DESCRIPTION
Prior to commit 31764950, the --runtime directory (default: ./runtime)
was both an input and an output, and was always populated.

Now that it's only an output, with --templates=./templates taking the
input role, rename the option to --output to make this more clear.

While I'm making incompatible changes anyway, instead of giving it a
new default, I've given it no default. Instead, we require at least one
of --output and --archive. If the only thing we are interested in
generating is a tar archive (as is the case for the official Steam
Runtime binary releases provided alongside Steam), then we can build
the runtime in a temporary directory, compress it into the archive, and
discard the temporary directory, removing the need for a wrapper script
to manage the temporary directory.