### PR TITLE
Keep .sh files with LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 runtime/common-licenses/* linguist-documentation
+*.sh text eol=lf


### PR DESCRIPTION
For mingw/cygwin execution on Windows.

(Patch from @TTimo)