### PR TITLE
Run gpg2 in --batch mode

### DIFF
--- a/docker_fetch_base_cloudimg.sh
+++ b/docker_fetch_base_cloudimg.sh
@@ -56,7 +56,7 @@ cd "$tmpdir"
 verify() {
   local targetdir="$1"
   # Import plaintext key
-  gpg2 --no-default-keyring --keyring ./ubuntu-cloud-key.gpg --import --armor --skip-verify < "$KEYFILE"
+  gpg2 --batch --no-default-keyring --keyring ./ubuntu-cloud-key.gpg --import --armor --skip-verify < "$KEYFILE"
   if gpgv2 --keyring ./ubuntu-cloud-key.gpg "$targetdir"/"$SIG_FILE" "$targetdir"/"$SHA_FILE"; then
     stat "SHA256SUMS file signature matches, checking checksum"
   else


### PR DESCRIPTION
This fixes "gpg: cannot open '/dev/tty': No such device or address"
error when running in current Debian 9.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=913614#27