### PR TITLE
build-runtime: Improve normalization for paths in archive

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -897,7 +897,7 @@ if args.archive is not None:
 			rel_dir_path = os.path.relpath(
 				dir_path, args.output)
 
-			if not rel_dir_path.startswith('./'):
+			if rel_dir_path != '.' and not rel_dir_path.startswith('./'):
 				rel_dir_path = './' + rel_dir_path
 
 			for member in dirs:


### PR DESCRIPTION
When sorting archive members by name, we normalized `foo` to `./foo`
as intended, but also normalized `.` to `./.` not as intended. This
resulted in a predictable but odd archive order where the immediate
children of the top-level directory (including subdirectories like
amd64/ and scripts/) were all sorted before the contents of any
subdirectory (including for example amd64/).

Signed-off-by: Simon McVittie <smcv@collabora.com>