### PR TITLE
Fix project's misclassification on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
-runtime/common-licenses/* linguist-documentation
+# Stop license files from skewing language-stats on GitHub
+templates/common-licenses/* linguist-documentation linguist-language=Text
+
+# Enforce Unix-style line-endings for shell-scripts
 *.sh text eol=lf


### PR DESCRIPTION
This is a trivial patch to fix the project's egregious classification as a Roff repository:

<img src="https://user-images.githubusercontent.com/2346707/51727540-8a714700-20c0-11e9-8121-061d5b850a83.png" />

These three files are to blame, as GitHub thinks they're manpages because their filenames end in `.2`, `.1` and `.3`, which are common file extensions used by man-pages:
* [`templates/common-licenses/GFDL-1.2`](https://github.com/ValveSoftware/steam-runtime/blob/e019f6dcbf2dc57e6d249b72d8f5327b3653a9f7/templates/common-licenses/GFDL-1.2)
* [`templates/common-licenses/GFDL-1.3`](https://github.com/ValveSoftware/steam-runtime/blob/e019f6dcbf2dc57e6d249b72d8f5327b3653a9f7/templates/common-licenses/GFDL-1.3)
* [`templates/common-licenses/LGPL-2.1`](https://github.com/ValveSoftware/steam-runtime/blob/e019f6dcbf2dc57e6d249b72d8f5327b3653a9f7/templates/common-licenses/LGPL-2.1)