### PR TITLE
docker: Add support for no_proxy

### DIFF
--- a/setup_docker.sh
+++ b/setup_docker.sh
@@ -98,6 +98,8 @@ build_docker() # build_docker <imagename> <arch> [beta]
   stat "Building docker image"
   docker_run build --build-arg=arch="$arch" ${beta:+--build-arg=beta=1} \
              ${extra_bootstrap:+"--build-arg=extra_bootstrap=scripts/bootstrap-extra.sh"} \
+             ${proxy:+"--build-arg=proxy=${proxy}"} \
+             ${no_proxy:+"--build-arg=no_proxy=${no_proxy}"} \
              -t "$image" -f "$DOCKERFILE" "$SCRIPT_RELDIR"
 
   stat "Successfully built docker image: $image"
@@ -123,9 +125,11 @@ beta_arg="" # --beta?
 arch_arg="" # arch argument
 name_arg="" # name argument
 extra_bootstrap_arg="" # extra-bootstrap argument
+proxy="${http_proxy:-}"
+no_proxy="${no_proxy:-}"
 
 getopt_temp="$(getopt -o '' --long \
-'beta,extra-bootstrap:,help' \
+'beta,extra-bootstrap:,help,proxy:,no-proxy:' \
 -n "$0" -- "$@")"
 eval set -- "$getopt_temp"
 unset getopt_temp
@@ -144,6 +148,16 @@ while [ "$#" -gt 0 ]; do
       fi
 
       extra_bootstrap_arg="$2"
+      shift 2
+      ;;
+
+    (--proxy)
+      proxy="$2"
+      shift 2
+      ;;
+
+    (--no-proxy)
+      no_proxy="${no_proxy:+"${no_proxy},"}$2"
       shift 2
       ;;
 

--- a/steam-runtime.docker
+++ b/steam-runtime.docker
@@ -94,6 +94,9 @@ RUN apt-get -y install install-info
 ## Steam Runtime specific setup
 ##
 
+COPY write-manifest /root/
+RUN /root/write-manifest /
+
 COPY scripts/bootstrap-runtime.sh /root/
 RUN /root/bootstrap-runtime.sh --docker ${beta:+--beta}
 

--- a/steam-runtime.docker
+++ b/steam-runtime.docker
@@ -19,14 +19,32 @@ ARG proxy
 ##
 ADD ubuntu-precise-core-cloudimg-${arch}-root.tar.gz /
 
-RUN [ "x${proxy}" = "x" ] || ( \
-    echo "configure proxy" \
-    && echo export http_proxy=${proxy} >> /etc/bash.bashrc \
-    && echo export https_proxy=${proxy} >> /etc/bash.bashrc \
-    && echo export ftp_proxy=${proxy} >> /etc/bash.bashrc \
-    && echo Acquire::http::proxy \"${proxy}\"\; > /etc/apt/apt.conf.d/01proxy \
-    && echo Acquire::https::proxy \"${proxy}\"\; >> /etc/apt/apt.conf.d/01proxy \
-    )
+RUN \
+	set -xe; \
+	if [ -n "${proxy}" ]; then \
+		echo "configure proxy"; \
+		echo "export http_proxy=${proxy}" >> /etc/bash.bashrc; \
+		echo "export https_proxy=${proxy}" >> /etc/bash.bashrc; \
+		echo "export ftp_proxy=${proxy}" >> /etc/bash.bashrc; \
+		echo "Acquire::http::proxy \"${proxy}\";" > /etc/apt/apt.conf.d/01proxy; \
+		echo "Acquire::https::proxy \"${proxy}\";" >> /etc/apt/apt.conf.d/01proxy; \
+	fi; \
+	if [ -n "${no_proxy}" ]; then \
+		echo "export no_proxy=${no_proxy}" >> /etc/bash.bashrc; \
+		oldIFS="$IFS"; \
+		IFS=","; \
+		for nope in ${no_proxy}; do \
+			case "$nope" in \
+				(.*) \
+					;; \
+				(*) \
+					echo "Acquire::http::proxy::${nope} \"DIRECT\";" >> /etc/apt/apt.conf.d/01proxy; \
+					echo "Acquire::https::proxy::${nope} \"DIRECT\";" >> /etc/apt/apt.conf.d/01proxy; \
+					;; \
+			esac; \
+		done; \
+		IFS="$oldIFS"; \
+	fi
 
 RUN set -xe \
 	\


### PR DESCRIPTION
This branch refactors `setup_docker.sh` to use `getopt` for consistent option parsing, then adds `--proxy` and `--no-proxy` options, defaulting to `${http_proxy}` and `${no_proxy}` respectively. It also configures apt in the Docker container to use `DIRECT` mode for hosts listed in `no_proxy` (subdomains like `no_proxy=.example.com` are not currently supported).