### PR TITLE
Add support for a jessie-based mini-runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ newpkg/
 /unofficial-steam-runtime-sdk-chroot-*.deb822.gz
 /unofficial-steam-runtime-sdk-chroot-*.tar.gz
 /unofficial-steam-runtime-sdk-chroot-*.txt
+*.pyc

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -31,7 +31,6 @@ except ImportError:
 	from urllib import (urlopen, urlretrieve)
 
 destdir="newpkg"
-arches=["amd64", "i386"]
 
 # The top level directory
 top = sys.path[0]
@@ -154,6 +153,11 @@ def parse_args():
 	parser.add_argument(
 		'--split', default=None,
 		help='Also generate an archive split into 50M parts')
+	parser.add_argument(
+		'--architecture', '--arch',
+		help='include architecture',
+		action='append', dest='architectures', default=[],
+	)
 
 	args = parser.parse_args()
 
@@ -177,6 +181,9 @@ def parse_args():
 		parser.error(
 			'Argument to --output, %r, must not already exist'
 			% args.output)
+
+	if not args.architectures:
+		args.architectures = ['amd64', 'i386']
 
 	return args
 
@@ -327,7 +334,7 @@ def list_binaries(apt_sources, dbgsym=False):
 	else:
 		description = 'binaries'
 
-	for arch in arches:
+	for arch in args.architectures:
 		by_name = {}
 
 		# Load the Packages files so we can find the location of each
@@ -538,7 +545,7 @@ def install_symbols(dbgsym_by_arch, binarylist, manifest):
 # to their relative equivalent
 #
 def fix_symlinks ():
-	for arch in arches:
+	for arch in args.architectures:
 		for dir, subdirs, files in os.walk(os.path.join(args.output, arch)):
 			for name in files:
 				filepath=os.path.join(dir,name)
@@ -561,7 +568,7 @@ def fix_symlinks ():
 # symbols
 #
 def fix_debuglinks ():
-	for arch in arches:
+	for arch in args.architectures:
 		for dir, subdirs, files in os.walk(os.path.join(args.output, arch, "usr/lib/debug")):
 			if ".build-id" in subdirs:
 				subdirs.remove(".build-id")		# don't recurse into .build-id directory we are creating

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -103,7 +103,7 @@ class AptSource:
 			maybe_debug = ''
 
 		return [
-			"%s/dists/%s/%s/%sbinary-%s/Packages" % (
+			"%s/dists/%s/%s/%sbinary-%s/Packages.gz" % (
 				self.url, self.suite, component,
 				maybe_debug, arch)
 			for component in self.components
@@ -352,7 +352,12 @@ def list_binaries(apt_sources, dbgsym=False):
 					arch, description, url))
 
 				try:
-					url_file_handle = BytesIO(urlopen(url).read())
+					# Python 2 does not catch a 404 here
+					url_file_handle = gzip.GzipFile(
+                                                fileobj=BytesIO(
+                                                        urlopen(url).read()
+                                                )
+                                        )
 				except Exception as e:
 					if dbgsym:
 						print(e)

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -354,10 +354,10 @@ def list_binaries(apt_sources, dbgsym=False):
 				try:
 					# Python 2 does not catch a 404 here
 					url_file_handle = gzip.GzipFile(
-                                                fileobj=BytesIO(
-                                                        urlopen(url).read()
-                                                )
-                                        )
+						fileobj=BytesIO(
+							urlopen(url).read()
+						)
+					)
 				except Exception as e:
 					if dbgsym:
 						print(e)

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -159,6 +159,11 @@ def parse_args():
 		action='append', dest='architectures', default=[],
 	)
 	parser.add_argument(
+		'--packages-from',
+		help='Include packages listed in the given file',
+		action='append', default=[],
+	)
+	parser.add_argument(
 		'--dump-options', action='store_true',
 		help=argparse.SUPPRESS,		# deliberately undocumented
 	)
@@ -188,6 +193,9 @@ def parse_args():
 
 	if not args.architectures:
 		args.architectures = ['amd64', 'i386']
+
+	if not args.packages_from:
+		args.packages_from = ['packages.txt']
 
 	return args
 
@@ -850,13 +858,14 @@ binary_pkgs = set()
 
 print("Creating Steam Runtime in %s" % args.output)
 
-with open("packages.txt") as f:
-	for line in f:
-		if line[0] != '#':
-			toks = line.split()
-			if len(toks) > 1:
-				source_pkgs.add(toks[0])
-				binary_pkgs.update(toks[1:])
+for packages_from in args.packages_from:
+	with open(packages_from) as f:
+		for line in f:
+			if line[0] != '#':
+				toks = line.split()
+				if len(toks) > 1:
+					source_pkgs.add(toks[0])
+					binary_pkgs.update(toks[1:])
 
 # remove development packages for end-user runtime
 if not args.debug:

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -158,6 +158,10 @@ def parse_args():
 		help='include architecture',
 		action='append', dest='architectures', default=[],
 	)
+	parser.add_argument(
+		'--dump-options', action='store_true',
+		help=argparse.SUPPRESS,		# deliberately undocumented
+	)
 
 	args = parser.parse_args()
 
@@ -791,6 +795,20 @@ else:
 	version = time.strftime('snapshot-%Y%m%d-%H%M%SZ', time.gmtime())
 
 name_version = '%s_%s' % (name, version)
+
+if args.dump_options:
+	dump = vars(args)
+	dump['name'] = name
+	dump['version'] = version
+	dump['name_version'] = name_version
+	dump['reference_timestamp'] = reference_timestamp
+	dump['apt_sources'] = []
+	for source in apt_sources:
+		dump['apt_sources'].append(str(source))
+	import json
+	json.dump(dump, sys.stdout, indent=4, sort_keys=True)
+	sys.stdout.write('\n')
+	sys.exit(0)
 
 tmpdir = tempfile.mkdtemp(prefix='build-runtime-')
 

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -232,7 +232,7 @@ def install_sources(apt_sources, sourcelist):
 					SourcePackage(apt_source, stanza))
 
 	skipped = 0
-	unpacked = []
+	unpacked = {}
 	manifest_lines = set()
 
 	# Walk through the Sources file and process any requested packages.
@@ -286,7 +286,7 @@ def install_sources(apt_sources, sourcelist):
 				if args.verbose or re.match(r'dpkg-source: warning: ',line):
 					print(line, end='')
 
-			unpacked.append((p, sp.stanza['Version'], sp.stanza))
+			unpacked[(p, sp.stanza['Version'])] = sp.stanza
 			manifest_lines.add(
 				'%s\t%s\t%s\n' % (
 					p, sp.stanza['Version'],
@@ -310,11 +310,11 @@ def install_sources(apt_sources, sourcelist):
 		) as stanza_writer:
 			done_one = False
 
-			for source in sorted(unpacked):
+			for key, stanza in sorted(unpacked.items()):
 				if done_one:
 					stanza_writer.write(b'\n')
 
-				source[2].dump(stanza_writer)
+				stanza.dump(stanza_writer)
 				done_one = True
 
 	if skipped > 0:

--- a/tests/build-runtime.py
+++ b/tests/build-runtime.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# Copyright (C) 2019 Collabora Ltd.
+#
+# SPDX-License-Identifier: MIT
+# (see COPYING)
+
+from __future__ import print_function
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+try:
+    import typing
+    typing      # silence pyflakes
+except ImportError:
+    pass
+
+
+BUILD_RUNTIME = os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    'build-runtime.py',
+)
+
+
+class TestBuildRuntime(unittest.TestCase):
+    def setUp(self):
+        # type: () -> None
+        pass
+
+    def test_default(self):
+        j = subprocess.check_output([
+            BUILD_RUNTIME,
+            '--archive=runtime/',
+            '--dump-options',
+        ])
+        o = json.loads(j, encoding='utf-8')
+        self.assertEqual(o['architectures'], ['amd64', 'i386'])
+
+    def test_architectures(self):
+        j = subprocess.check_output([
+            BUILD_RUNTIME,
+            '--archive=runtime/',
+            '--dump-options',
+            '--arch', 'mips',
+            '--arch', 'mipsel',
+        ])
+        o = json.loads(j, encoding='utf-8')
+        self.assertEqual(o['architectures'], ['mips', 'mipsel'])
+
+    def tearDown(self):
+        # type: () -> None
+        pass
+
+
+if __name__ == '__main__':
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'third-party'))
+    from pycotap import TAPTestRunner
+    unittest.main(verbosity=2, testRunner=TAPTestRunner)
+
+# vi: set sw=4 sts=4 et:

--- a/tests/build-runtime.py
+++ b/tests/build-runtime.py
@@ -39,6 +39,7 @@ class TestBuildRuntime(unittest.TestCase):
         ])
         o = json.loads(j, encoding='utf-8')
         self.assertEqual(o['architectures'], ['amd64', 'i386'])
+        self.assertEqual(o['packages_from'], ['packages.txt'])
 
     def test_architectures(self):
         j = subprocess.check_output([
@@ -50,6 +51,20 @@ class TestBuildRuntime(unittest.TestCase):
         ])
         o = json.loads(j, encoding='utf-8')
         self.assertEqual(o['architectures'], ['mips', 'mipsel'])
+
+    def test_packages_from(self):
+        j = subprocess.check_output([
+            BUILD_RUNTIME,
+            '--archive=runtime/',
+            '--dump-options',
+            '--packages-from', '/tmp/packages.txt',
+            '--packages-from', 'foobar.txt',
+        ])
+        o = json.loads(j, encoding='utf-8')
+        self.assertEqual(
+            o['packages_from'],
+            ['/tmp/packages.txt', 'foobar.txt'],
+        )
 
     def tearDown(self):
         # type: () -> None

--- a/tests/pycodestyle.sh
+++ b/tests/pycodestyle.sh
@@ -17,7 +17,7 @@ fi
 echo "1..2"
 
 if "${PYCODESTYLE}" \
-    --ignore=W191,E211,E225,E231,E501 \
+    --ignore=W191,E211,E225,E231,E501,W503 \
     build-runtime.py \
     >&2; then
     echo "ok 1 - $PYCODESTYLE reported no issues"

--- a/tests/third-party/pycotap.py
+++ b/tests/third-party/pycotap.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright (c) 2015 Remko Tronçon (https://el-tramo.be)
+# Released under the MIT license
+# See COPYING for details
+
+
+import unittest
+import sys
+import base64
+if sys.hexversion >= 0x03000000:
+  from io import StringIO
+else:
+  from StringIO import StringIO
+
+# Log modes
+class LogMode(object) :
+  LogToError, LogToDiagnostics, LogToYAML, LogToAttachment = range(4)
+
+
+class TAPTestResult(unittest.TestResult):
+  def __init__(self, output_stream, error_stream, message_log, test_output_log):
+    super(TAPTestResult, self).__init__(self, output_stream)
+    self.output_stream = output_stream
+    self.error_stream = error_stream
+    self.orig_stdout = None
+    self.orig_stderr = None
+    self.message = None
+    self.test_output = None
+    self.message_log = message_log
+    self.test_output_log = test_output_log
+    self.output_stream.write("TAP version 13\n")
+    self._set_streams()
+
+  def printErrors(self):
+    self.print_raw("1..%d\n" % self.testsRun)
+    self._reset_streams()
+
+  def _set_streams(self):
+    self.orig_stdout = sys.stdout
+    self.orig_stderr = sys.stderr
+    if self.message_log == LogMode.LogToError:
+      self.message = self.error_stream
+    else:
+      self.message = StringIO()
+    if self.test_output_log == LogMode.LogToError:
+      self.test_output = self.error_stream
+    else:
+      self.test_output = StringIO()
+
+    if self.message_log == self.test_output_log:
+      self.test_output = self.message
+    sys.stdout = sys.stderr = self.test_output
+
+  def _reset_streams(self):
+    sys.stdout = self.orig_stdout
+    sys.stderr = self.orig_stderr
+
+
+  def print_raw(self, text):
+    self.output_stream.write(text)
+    self.output_stream.flush()
+
+  def print_result(self, result, test, directive = None):
+    self.output_stream.write("%s %d %s" % (result, self.testsRun, test.id()))
+    if directive:
+      self.output_stream.write(" # " + directive)
+    self.output_stream.write("\n")
+    self.output_stream.flush()
+
+  def ok(self, test, directive = None):
+    self.print_result("ok", test, directive)
+
+  def not_ok(self, test):
+    self.print_result("not ok", test)
+
+  def startTest(self, test):
+    super(TAPTestResult, self).startTest(test)
+
+  def stopTest(self, test):
+    super(TAPTestResult, self).stopTest(test)
+    if self.message_log == self.test_output_log:
+      logs = [(self.message_log, self.message, "output")]
+    else:
+      logs = [
+          (self.test_output_log, self.test_output, "test_output"),
+          (self.message_log, self.message, "message")
+      ]
+    for log_mode, log, log_name in logs:
+      if log_mode != LogMode.LogToError:
+        output = log.getvalue()
+        if len(output):
+          if log_mode == LogMode.LogToYAML:
+            self.print_raw("  ---\n")
+            self.print_raw("    " + log_name + ": |\n")
+            self.print_raw("      " + output.rstrip().replace("\n", "\n      ") + "\n")
+            self.print_raw("  ...\n")
+          elif log_mode == LogMode.LogToAttachment:
+            self.print_raw("  ---\n")
+            self.print_raw("    " + log_name + ":\n")
+            self.print_raw("      File-Name: " + log_name + ".txt\n")
+            self.print_raw("      File-Type: text/plain\n")
+            self.print_raw("      File-Content: " + base64.b64encode(output) + "\n")
+            self.print_raw("  ...\n")
+          else:
+            self.print_raw("# " + output.rstrip().replace("\n", "\n# ") + "\n")
+        log.truncate(0)
+
+  def addSuccess(self, test):
+    super(TAPTestResult, self).addSuccess(test)
+    self.ok(test)
+
+  def addError(self, test, err):
+    super(TAPTestResult, self).addError(test, err)
+    self.message.write(self.errors[-1][1] + "\n")
+    self.not_ok(test)
+
+  def addFailure(self, test, err):
+    super(TAPTestResult, self).addFailure(test, err)
+    self.message.write(self.failures[-1][1] + "\n")
+    self.not_ok(test)
+
+  def addSkip(self, test, reason):
+    super(TAPTestResult, self).addSkip(test, reason)
+    self.ok(test, "SKIP " + reason)
+
+  def addExpectedFailure(self, test, err):
+    super(TAPTestResult, self).addExpectedFailure(test, err)
+    self.ok(test)
+
+  def addUnexpectedSuccess(self, test):
+    super(TAPTestResult, self).addUnexpectedSuccess(test)
+    self.message.write("Unexpected success" + "\n")
+    self.not_ok(test)
+
+
+class TAPTestRunner(object):
+  def __init__(self, 
+      message_log = LogMode.LogToYAML,
+      test_output_log = LogMode.LogToDiagnostics, 
+      output_stream = sys.stdout, error_stream = sys.stderr):
+    self.output_stream = output_stream
+    self.error_stream = error_stream
+    self.message_log = message_log
+    self.test_output_log = test_output_log
+
+  def run(self, test):
+    result = TAPTestResult(
+        self.output_stream, 
+        self.error_stream, 
+        self.message_log, 
+        self.test_output_log)
+    test(result)
+    result.printErrors()
+
+    return result

--- a/webhelper/packages.txt
+++ b/webhelper/packages.txt
@@ -7,7 +7,7 @@ libdatrie libdatrie1
 dbus libdbus-1-3
 expat libexpat1
 libffi libffi6
-fontconfig fontconfig libfontconfig1
+fontconfig libfontconfig1
 freetype libfreetype6
 gcc-4.9 libgcc1
 glib2.0 libglib2.0-0

--- a/webhelper/packages.txt
+++ b/webhelper/packages.txt
@@ -9,7 +9,7 @@ expat libexpat1
 libffi libffi6
 fontconfig fontconfig libfontconfig1
 freetype libfreetype6
-gcc-8 libgcc1
+gcc-4.9 libgcc1
 glib2.0 libglib2.0-0
 graphite2 libgraphite2-3
 harfbuzz libharfbuzz0b

--- a/webhelper/packages.txt
+++ b/webhelper/packages.txt
@@ -1,0 +1,38 @@
+alsa-lib libasound2
+atk1.0 libatk1.0-0
+at-spi2-atk libatk-bridge2.0-0
+at-spi2-core libatspi2.0-0
+cairo libcairo2
+libdatrie libdatrie1
+dbus libdbus-1-3
+expat libexpat1
+libffi libffi6
+fontconfig fontconfig libfontconfig1
+freetype libfreetype6
+gcc-8 libgcc1
+glib2.0 libglib2.0-0
+graphite2 libgraphite2-3
+harfbuzz libharfbuzz0b
+nspr libnspr4
+nss libnss3
+pango1.0 libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0
+pcre3 libpcre3
+pixman libpixman-1-0
+libpng libpng12-0
+libselinux libselinux1
+libthai libthai0
+libx11 libx11-6 libx11-xcb1
+libxau libxau6
+libxcb libxcb1 libxcb-render0 libxcb-shm0
+libxcomposite libxcomposite1
+libxcursor libxcursor1
+libxdamage libxdamage1
+libxdmcp libxdmcp6
+libxext libxext6
+libxfixes libxfixes3
+libxi libxi6
+libxrandr libxrandr2
+libxrender libxrender1
+libxss libxss1
+libxtst libxtst6
+zlib zlib1g


### PR DESCRIPTION
To test, for example:

```
python3 ./build-runtime.py \
--arch amd64 \
--archive runtime/ \
--repo http://.../steamrt-heavy \
--set-version ... \
--suite heavy \
--packages-from webhelper/packages.txt \
--extra-apt-source 'both http://deb.debian.org/debian jessie main' \
--extra-apt-source 'both http://deb.debian.org/debian jessie-updates main' \
--extra-apt-source 'both http://security.debian.org/debian-security jessie/updates main' \
--verbose \
--strict \
${NULL}
```