### PR TITLE
Add automated tests for setup_*.sh

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,6 @@
+steam-runtime (0) UNRELEASED; urgency=medium
+
+  * This is not a real Debian package. It's only here as a way to
+    provide automated tests in autopkgtest format.
+
+ -- Simon McVittie <smcv@collabora.com>  Wed, 06 Mar 2019 11:51:41 +0000

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,11 @@
+Source: steam-runtime
+Section: misc
+Priority: extra
+Maintainer: SteamOS Maintainers <steamos@valvesoftware.com>
+Standards-Version: 4.3.0
+
+Package: steam-runtime
+Architecture: all
+Description: Not a real package
+ This package description is only here as a way to run tests using
+ Debian's autopkgtest tool. Don't build it.

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,14 @@
+#!/usr/bin/make -f
+
+build:
+	@echo "This is not really a Debian package. Don't build it."
+	@false
+
+clean:
+	@:
+
+binary-arch: build
+binary-indep: build
+binary: binary-indep binary-arch
+build-arch: build
+build-indep: build

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,0 +1,7 @@
+Tests: setup-chroot.py
+Depends: bsdutils, debootstrap, python3, python3-debian, schroot, sudo
+Restrictions: allow-stderr, breaks-testbed, isolation-machine, needs-root
+
+Tests: setup-docker.py
+Depends: docker.io, gnupg (>= 2) | gnupg2, gpgv (>= 2) | gpgv, python3, python3-debian, sudo, wget
+Restrictions: allow-stderr, breaks-testbed, isolation-machine, needs-root

--- a/debian/tests/extra-bootstrap.sh
+++ b/debian/tests/extra-bootstrap.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+echo Docker > /etc/debian_chroot

--- a/debian/tests/setup-chroot.py
+++ b/debian/tests/setup-chroot.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# Copyright 2019 Collabora Ltd.
+#
+# SPDX-License-Identifier: MIT
+# (see build-runtime.py)
+
+from __future__ import print_function
+
+import os
+import os.path
+import subprocess
+import sys
+import unittest
+
+try:
+    import typing
+    typing      # silence pyflakes
+except ImportError:
+    pass
+
+
+SETUP_CHROOT = os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    os.pardir,
+    'setup_chroot.sh',
+)
+
+
+class TestBuildRuntime(unittest.TestCase):
+    def setUp(self):
+        # type: () -> None
+        pass
+
+    def test_default(self):
+        # Send stdout to our stderr to avoid interfering with TAP.
+        # Use fd 2 directly because pycotap reopens sys.stdout, sys.stderr
+        subprocess.check_call([
+            SETUP_CHROOT,
+            '--amd64',
+        ], stdout=2, stderr=2)
+        self.assertTrue(
+            os.path.exists(
+                '/var/chroots/steamrt_scout_amd64/etc/debian_chroot'))
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_amd64',
+            '--',
+            'uname', '-m',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'x86_64\n')
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_amd64',
+            '--',
+            'dpkg', '--print-architecture',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'amd64\n')
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_amd64',
+            '--',
+            'cat', '/etc/debian_chroot',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'steamrt_scout_amd64\n')
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_amd64',
+            '--',
+            'readlink', '-f', '/usr/bin/gcc'
+        ], universal_newlines=True)
+        self.assertEqual(output, '/usr/bin/gcc-4.8\n')
+
+        artifacts = os.getenv('AUTOPKGTEST_ARTIFACTS')
+
+        if artifacts is not None:
+            os.makedirs(os.path.join(artifacts, 'schroot', 'amd64'))
+
+            untar = subprocess.Popen([
+                'tar', '-C', os.path.join(artifacts, 'schroot', 'amd64'),
+                '-xf-',
+            ], stdin=subprocess.PIPE)
+            tar = subprocess.Popen([
+                'schroot',
+                '-c', 'steamrt_scout_amd64',
+                '--',
+                'tar', '-C', '/usr',
+                '-cf-',
+                'manifest.dpkg',
+                'manifest.dpkg.built-using',
+                'manifest.deb822.gz',
+            ], stdout=untar.stdin)
+            self.assertEqual(tar.wait(), 0)
+            self.assertEqual(untar.wait(), 0)
+
+    def test_other(self):
+        subprocess.check_call([
+            SETUP_CHROOT,
+            '--i386',
+            '--beta',
+            '--output-dir', '/opt',
+        ])
+        self.assertTrue(
+            os.path.exists(
+                '/opt/steamrt_scout_beta_i386/etc/debian_chroot'))
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_beta_i386',
+            '--',
+            'uname', '-m',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'i686\n')
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_beta_i386',
+            '--',
+            'dpkg', '--print-architecture',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'i386\n')
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_beta_i386',
+            '--',
+            'cat', '/etc/debian_chroot',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'steamrt_scout_beta_i386\n')
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_beta_i386',
+            '--',
+            'readlink', '-f', '/usr/bin/gcc'
+        ], universal_newlines=True)
+        self.assertEqual(output, '/usr/bin/gcc-4.8\n')
+
+        artifacts = os.getenv('AUTOPKGTEST_ARTIFACTS')
+
+        if artifacts is not None:
+            os.makedirs(os.path.join(artifacts, 'schroot', 'i386-beta'))
+
+            untar = subprocess.Popen([
+                'tar', '-C', os.path.join(artifacts, 'schroot', 'i386-beta'),
+                '-xf-',
+            ], stdin=subprocess.PIPE)
+            tar = subprocess.Popen([
+                'schroot',
+                '-c', 'steamrt_scout_beta_i386',
+                '--',
+                'tar', '-C', '/usr',
+                '-cf-',
+                'manifest.dpkg',
+                'manifest.dpkg.built-using',
+                'manifest.deb822.gz',
+            ], stdout=untar.stdin)
+            self.assertEqual(tar.wait(), 0)
+            self.assertEqual(untar.wait(), 0)
+
+    def tearDown(self):
+        # type: () -> None
+        pass
+
+
+if __name__ == '__main__':
+    if sys.argv[1:2] == ['--no-reexec']:
+        sys.argv[1:] = sys.argv[2:]
+    elif os.getuid() == 0:
+        normal_user = os.getenv('AUTOPKGTEST_NORMAL_USER')
+
+        if normal_user is None:
+            print('1..0 # SKIP Normal user required')
+            sys.exit(0)
+
+        subprocess.check_call(['adduser', normal_user, 'sudo'])
+        env = []
+        for var in (
+            'AUTOPKGTEST_ARTIFACTS', 'AUTOPKGTEST_NORMAL_USER',
+            'AUTOPKGTEST_REBOOT_MARK', 'AUTOPKGTEST_TMP',
+            'http_proxy', 'https_proxy', 'no_proxy',
+        ):
+            if var in os.environ:
+                env.append('%s=%s' % (var, os.getenv(var)))
+        os.execvp(
+            'runuser',
+            [
+                'runuser',
+                '--login',
+                '--shell=/bin/sh',
+                '-c', 'exec "$@"',
+                normal_user,
+                '--',
+                'sh',   # argv[0]
+                'env',
+            ] + env + [
+                __file__,
+                '--no-reexec',
+            ] + sys.argv[1:],
+        )
+
+    sys.path[:0] = [
+        os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            os.pardir,
+            'tests',
+            'third-party',
+        )
+    ]
+    from pycotap import TAPTestRunner
+    unittest.main(verbosity=2, testRunner=TAPTestRunner)
+
+# vi: set sw=4 sts=4 et:

--- a/debian/tests/setup-docker.py
+++ b/debian/tests/setup-docker.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# Copyright 2019 Collabora Ltd.
+#
+# SPDX-License-Identifier: MIT
+# (see build-runtime.py)
+
+from __future__ import print_function
+
+import os
+import os.path
+import subprocess
+import sys
+import unittest
+
+try:
+    import typing
+    typing      # silence pyflakes
+except ImportError:
+    pass
+
+
+SETUP_DOCKER = os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    os.pardir,
+    'setup_docker.sh',
+)
+
+EXTRA_BOOTSTRAP = os.path.join(
+    os.path.dirname(__file__),
+    'extra-bootstrap.sh',
+)
+
+
+class TestBuildRuntime(unittest.TestCase):
+    def setUp(self):
+        # type: () -> None
+        pass
+
+    def test_default(self):
+        # Send stdout to our stderr to avoid interfering with TAP.
+        # Use fd 2 directly because pycotap reopens sys.stdout, sys.stderr
+        subprocess.check_call([
+            SETUP_DOCKER,
+            'amd64',
+        ], stdout=2, stderr=2)
+
+        output = subprocess.check_output([
+            'docker', 'run',
+            '--rm', '--init',
+            'steam-runtime-amd64',
+            '/dev/init', '-sg',
+            '--',
+            'uname', '-m',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'x86_64\n')
+
+        output = subprocess.check_output([
+            'docker', 'run',
+            '--rm', '--init',
+            'steam-runtime-amd64',
+            '/dev/init', '-sg',
+            '--',
+            'dpkg', '--print-architecture',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'amd64\n')
+
+        output = subprocess.check_output([
+            'docker', 'run',
+            '--rm', '--init',
+            'steam-runtime-amd64',
+            '/dev/init', '-sg',
+            '--',
+            'readlink', '-f', '/usr/bin/gcc'
+        ], universal_newlines=True)
+        self.assertEqual(output, '/usr/bin/gcc-4.8\n')
+
+        artifacts = os.getenv('AUTOPKGTEST_ARTIFACTS')
+
+        if artifacts is not None:
+            os.makedirs(os.path.join(artifacts, 'docker', 'amd64'))
+
+            untar = subprocess.Popen([
+                'tar', '-C', os.path.join(artifacts, 'docker', 'amd64'),
+                '-xf-',
+            ], stdin=subprocess.PIPE)
+            tar = subprocess.Popen([
+                'docker', 'run', '--rm', '--init',
+                'steam-runtime-amd64',
+                '/dev/init', '-sg',
+                '--',
+                'tar', '-C', '/usr',
+                '-cf-',
+                'manifest.dpkg',
+                'manifest.dpkg.built-using',
+                'manifest.deb822.gz',
+            ], stdout=untar.stdin)
+            self.assertEqual(tar.wait(), 0)
+            self.assertEqual(untar.wait(), 0)
+
+    def test_other(self):
+        subprocess.check_call([
+            SETUP_DOCKER,
+            '--beta',
+            '--extra-bootstrap', EXTRA_BOOTSTRAP,
+            'i386',
+        ])
+
+        output = subprocess.check_output([
+            'docker', 'run',
+            '--rm', '--init',
+            'steam-runtime-i386-beta',
+            '/dev/init', '-sg',
+            '--',
+            'dpkg', '--print-architecture',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'i386\n')
+
+        output = subprocess.check_output([
+            'docker', 'run',
+            '--rm', '--init',
+            'steam-runtime-i386-beta',
+            '/dev/init', '-sg',
+            '--',
+            'readlink', '-f', '/usr/bin/gcc'
+        ], universal_newlines=True)
+        self.assertEqual(output, '/usr/bin/gcc-4.8\n')
+
+        output = subprocess.check_output([
+            'docker', 'run',
+            '--rm', '--init',
+            'steam-runtime-i386-beta',
+            '/dev/init', '-sg',
+            '--',
+            'cat', '/etc/debian_chroot',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'Docker\n')
+
+        artifacts = os.getenv('AUTOPKGTEST_ARTIFACTS')
+
+        if artifacts is not None:
+            os.makedirs(os.path.join(artifacts, 'docker', 'i386-beta'))
+
+            untar = subprocess.Popen([
+                'tar', '-C', os.path.join(artifacts, 'docker', 'i386-beta'),
+                '-xf-',
+            ], stdin=subprocess.PIPE)
+            tar = subprocess.Popen([
+                'docker', 'run', '--rm', '--init',
+                'steam-runtime-i386-beta',
+                '/dev/init', '-sg',
+                '--',
+                'tar', '-C', '/usr',
+                '-cf-',
+                'manifest.dpkg',
+                'manifest.dpkg.built-using',
+                'manifest.deb822.gz',
+            ], stdout=untar.stdin)
+            self.assertEqual(tar.wait(), 0)
+            self.assertEqual(untar.wait(), 0)
+
+    def tearDown(self):
+        # type: () -> None
+        pass
+
+
+if __name__ == '__main__':
+    if sys.argv[1:2] == ['--no-reexec']:
+        sys.argv[1:] = sys.argv[2:]
+    elif os.getuid() == 0:
+        normal_user = os.getenv('AUTOPKGTEST_NORMAL_USER')
+
+        if normal_user is None:
+            print('1..0 # SKIP Normal user required')
+            sys.exit(0)
+
+        subprocess.check_call(['adduser', normal_user, 'sudo'])
+        subprocess.check_call(['adduser', normal_user, 'docker'])
+        env = []
+        for var in (
+            'AUTOPKGTEST_ARTIFACTS', 'AUTOPKGTEST_NORMAL_USER',
+            'AUTOPKGTEST_REBOOT_MARK', 'AUTOPKGTEST_TMP',
+            'http_proxy', 'https_proxy', 'no_proxy',
+        ):
+            if var in os.environ:
+                env.append('%s=%s' % (var, os.getenv(var)))
+        os.execvp(
+            'runuser',
+            [
+                'runuser',
+                '--login',
+                '--shell=/bin/sh',
+                '-c', 'exec "$@"',
+                normal_user,
+                '--',
+                'sh',   # argv[0]
+                'env',
+            ] + env + [
+                __file__,
+                '--no-reexec',
+            ] + sys.argv[1:],
+        )
+
+    sys.path[:0] = [
+        os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            os.pardir,
+            'tests',
+            'third-party',
+        )
+    ]
+    from pycotap import TAPTestRunner
+    unittest.main(verbosity=2, testRunner=TAPTestRunner)
+
+# vi: set sw=4 sts=4 et:

--- a/tests/mypy.sh
+++ b/tests/mypy.sh
@@ -21,7 +21,7 @@ for script in \
             --python-executable="${PYTHON:=python3}" \
             --follow-imports=skip \
             --ignore-missing-imports \
-            $script; then
+            "$script"; then
         echo "ok $i - $script"
     else
         echo "not ok $i - $script # TODO mypy issues reported"

--- a/tests/mypy.sh
+++ b/tests/mypy.sh
@@ -12,6 +12,7 @@ export MYPYPATH="${PYTHONPATH:=$(pwd)}"
 
 i=0
 for script in \
+    debian/tests/*.py \
     tests/*.py \
 ; do
     i=$((i + 1))

--- a/tests/pycodestyle.sh
+++ b/tests/pycodestyle.sh
@@ -26,6 +26,7 @@ else
 fi
 
 if "${PYCODESTYLE}" \
+    debian/tests/*.py \
     tests/*.py \
     >&2; then
     echo "ok 2 - $PYCODESTYLE reported no issues"

--- a/tests/pyflakes.sh
+++ b/tests/pyflakes.sh
@@ -13,6 +13,7 @@ if [ "x${PYFLAKES:=pyflakes3}" = xfalse ] || \
     echo "1..0 # SKIP pyflakes3 not found"
 elif "${PYFLAKES}" \
     ./*.py \
+    debian/tests/*.py \
     tests/*.py \
     >&2; then
     echo "1..1"

--- a/tests/pyflakes.sh
+++ b/tests/pyflakes.sh
@@ -12,7 +12,7 @@ if [ "x${PYFLAKES:=pyflakes3}" = xfalse ] || \
         [ -z "$(command -v "$PYFLAKES")" ]; then
     echo "1..0 # SKIP pyflakes3 not found"
 elif "${PYFLAKES}" \
-    *.py \
+    ./*.py \
     tests/*.py \
     >&2; then
     echo "1..1"

--- a/tests/third-party/pycotap.py
+++ b/tests/third-party/pycotap.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright (c) 2015 Remko Tronçon (https://el-tramo.be)
+# Released under the MIT license
+# See COPYING for details
+
+
+import unittest
+import sys
+import base64
+if sys.hexversion >= 0x03000000:
+  from io import StringIO
+else:
+  from StringIO import StringIO
+
+# Log modes
+class LogMode(object) :
+  LogToError, LogToDiagnostics, LogToYAML, LogToAttachment = range(4)
+
+
+class TAPTestResult(unittest.TestResult):
+  def __init__(self, output_stream, error_stream, message_log, test_output_log):
+    super(TAPTestResult, self).__init__(self, output_stream)
+    self.output_stream = output_stream
+    self.error_stream = error_stream
+    self.orig_stdout = None
+    self.orig_stderr = None
+    self.message = None
+    self.test_output = None
+    self.message_log = message_log
+    self.test_output_log = test_output_log
+    self.output_stream.write("TAP version 13\n")
+    self._set_streams()
+
+  def printErrors(self):
+    self.print_raw("1..%d\n" % self.testsRun)
+    self._reset_streams()
+
+  def _set_streams(self):
+    self.orig_stdout = sys.stdout
+    self.orig_stderr = sys.stderr
+    if self.message_log == LogMode.LogToError:
+      self.message = self.error_stream
+    else:
+      self.message = StringIO()
+    if self.test_output_log == LogMode.LogToError:
+      self.test_output = self.error_stream
+    else:
+      self.test_output = StringIO()
+
+    if self.message_log == self.test_output_log:
+      self.test_output = self.message
+    sys.stdout = sys.stderr = self.test_output
+
+  def _reset_streams(self):
+    sys.stdout = self.orig_stdout
+    sys.stderr = self.orig_stderr
+
+
+  def print_raw(self, text):
+    self.output_stream.write(text)
+    self.output_stream.flush()
+
+  def print_result(self, result, test, directive = None):
+    self.output_stream.write("%s %d %s" % (result, self.testsRun, test.id()))
+    if directive:
+      self.output_stream.write(" # " + directive)
+    self.output_stream.write("\n")
+    self.output_stream.flush()
+
+  def ok(self, test, directive = None):
+    self.print_result("ok", test, directive)
+
+  def not_ok(self, test):
+    self.print_result("not ok", test)
+
+  def startTest(self, test):
+    super(TAPTestResult, self).startTest(test)
+
+  def stopTest(self, test):
+    super(TAPTestResult, self).stopTest(test)
+    if self.message_log == self.test_output_log:
+      logs = [(self.message_log, self.message, "output")]
+    else:
+      logs = [
+          (self.test_output_log, self.test_output, "test_output"),
+          (self.message_log, self.message, "message")
+      ]
+    for log_mode, log, log_name in logs:
+      if log_mode != LogMode.LogToError:
+        output = log.getvalue()
+        if len(output):
+          if log_mode == LogMode.LogToYAML:
+            self.print_raw("  ---\n")
+            self.print_raw("    " + log_name + ": |\n")
+            self.print_raw("      " + output.rstrip().replace("\n", "\n      ") + "\n")
+            self.print_raw("  ...\n")
+          elif log_mode == LogMode.LogToAttachment:
+            self.print_raw("  ---\n")
+            self.print_raw("    " + log_name + ":\n")
+            self.print_raw("      File-Name: " + log_name + ".txt\n")
+            self.print_raw("      File-Type: text/plain\n")
+            self.print_raw("      File-Content: " + base64.b64encode(output) + "\n")
+            self.print_raw("  ...\n")
+          else:
+            self.print_raw("# " + output.rstrip().replace("\n", "\n# ") + "\n")
+        log.truncate(0)
+
+  def addSuccess(self, test):
+    super(TAPTestResult, self).addSuccess(test)
+    self.ok(test)
+
+  def addError(self, test, err):
+    super(TAPTestResult, self).addError(test, err)
+    self.message.write(self.errors[-1][1] + "\n")
+    self.not_ok(test)
+
+  def addFailure(self, test, err):
+    super(TAPTestResult, self).addFailure(test, err)
+    self.message.write(self.failures[-1][1] + "\n")
+    self.not_ok(test)
+
+  def addSkip(self, test, reason):
+    super(TAPTestResult, self).addSkip(test, reason)
+    self.ok(test, "SKIP " + reason)
+
+  def addExpectedFailure(self, test, err):
+    super(TAPTestResult, self).addExpectedFailure(test, err)
+    self.ok(test)
+
+  def addUnexpectedSuccess(self, test):
+    super(TAPTestResult, self).addUnexpectedSuccess(test)
+    self.message.write("Unexpected success" + "\n")
+    self.not_ok(test)
+
+
+class TAPTestRunner(object):
+  def __init__(self, 
+      message_log = LogMode.LogToYAML,
+      test_output_log = LogMode.LogToDiagnostics, 
+      output_stream = sys.stdout, error_stream = sys.stderr):
+    self.output_stream = output_stream
+    self.error_stream = error_stream
+    self.message_log = message_log
+    self.test_output_log = test_output_log
+
+  def run(self, test):
+    result = TAPTestResult(
+        self.output_stream, 
+        self.error_stream, 
+        self.message_log, 
+        self.test_output_log)
+    test(result)
+    result.printErrors()
+
+    return result


### PR DESCRIPTION
Because these tests manipulate Docker and schroot, and use sudo, they should be run on a virtual machine (or a real machine that you don't mind possibly breaking); in particular they can't be run inside a typical Docker container. Debian's autopkgtest tool already knows how to run tests in qemu virtual machines, and we can make use of it by adding the basic structure of a Debian source package.

Example of use:

    autopkgtest-buildvm-ubuntu-cloud \
        --arch amd64 \
        --release bionic \
        ${http_proxy+--proxy "${http_proxy}"} \
        --verbose
    autopkgtest \
        --no-built-binaries \
        ${http_proxy+--env http_proxy="${http_proxy}"} \
        ${https_proxy+--env https_proxy="${https_proxy}"} \
        ${no_proxy+--env no_proxy="${no_proxy}"} \
        . -- qemu autopkgtest-bionic-amd64.img

This branch also adds some supporting infrastructure to make Python `unittest` output [TAP](http://testanything.org/), taken from https://github.com/remko/pycotap, and fixes some minor shellcheck warnings in the tests. See individual commit messages for details.