### PR TITLE
Check shell scripts with shellcheck

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,6 @@
+steam-runtime (0) UNRELEASED; urgency=medium
+
+  * This is not a real Debian package. It's only here as a way to
+    provide automated tests in autopkgtest format.
+
+ -- Simon McVittie <smcv@collabora.com>  Wed, 06 Mar 2019 11:51:41 +0000

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,11 @@
+Source: steam-runtime
+Section: misc
+Priority: extra
+Maintainer: SteamOS Maintainers <steamos@valvesoftware.com>
+Standards-Version: 4.3.0
+
+Package: steam-runtime
+Architecture: all
+Description: Not a real package
+ This package description is only here as a way to run tests using
+ Debian's autopkgtest tool. Don't build it.

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,14 @@
+#!/usr/bin/make -f
+
+build:
+	@echo "This is not really a Debian package. Don't build it."
+	@false
+
+clean:
+	@:
+
+binary-arch: build
+binary-indep: build
+binary: binary-indep binary-arch
+build-arch: build
+build-indep: build

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,0 +1,7 @@
+Tests: setup-chroot.py
+Depends: bsdutils, debootstrap, python3, python3-debian, schroot, sudo
+Restrictions: allow-stderr, breaks-testbed, isolation-machine, needs-root
+
+Tests: setup-docker.py
+Depends: docker.io, gnupg (>= 2) | gnupg2, gpgv (>= 2) | gpgv, python3, python3-debian, sudo, wget
+Restrictions: allow-stderr, breaks-testbed, isolation-machine, needs-root

--- a/debian/tests/extra-bootstrap.sh
+++ b/debian/tests/extra-bootstrap.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+echo Docker > /etc/debian_chroot

--- a/debian/tests/setup-chroot.py
+++ b/debian/tests/setup-chroot.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# Copyright 2019 Collabora Ltd.
+#
+# SPDX-License-Identifier: MIT
+# (see build-runtime.py)
+
+from __future__ import print_function
+
+import os
+import os.path
+import subprocess
+import sys
+import unittest
+
+try:
+    import typing
+    typing      # silence pyflakes
+except ImportError:
+    pass
+
+
+SETUP_CHROOT = os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    os.pardir,
+    'setup_chroot.sh',
+)
+
+
+class TestBuildRuntime(unittest.TestCase):
+    def setUp(self):
+        # type: () -> None
+        pass
+
+    def test_default(self):
+        # Send stdout to our stderr to avoid interfering with TAP.
+        # Use fd 2 directly because pycotap reopens sys.stdout, sys.stderr
+        subprocess.check_call([
+            SETUP_CHROOT,
+            '--amd64',
+        ], stdout=2, stderr=2)
+        self.assertTrue(
+            os.path.exists(
+                '/var/chroots/steamrt_scout_amd64/etc/debian_chroot'))
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_amd64',
+            '--',
+            'uname', '-m',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'x86_64\n')
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_amd64',
+            '--',
+            'dpkg', '--print-architecture',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'amd64\n')
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_amd64',
+            '--',
+            'cat', '/etc/debian_chroot',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'steamrt_scout_amd64\n')
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_amd64',
+            '--',
+            'readlink', '-f', '/usr/bin/gcc'
+        ], universal_newlines=True)
+        self.assertEqual(output, '/usr/bin/gcc-4.8\n')
+
+        artifacts = os.getenv('AUTOPKGTEST_ARTIFACTS')
+
+        if artifacts is not None:
+            os.makedirs(os.path.join(artifacts, 'schroot', 'amd64'))
+
+            untar = subprocess.Popen([
+                'tar', '-C', os.path.join(artifacts, 'schroot', 'amd64'),
+                '-xf-',
+            ], stdin=subprocess.PIPE)
+            tar = subprocess.Popen([
+                'schroot',
+                '-c', 'steamrt_scout_amd64',
+                '--',
+                'tar', '-C', '/usr',
+                '-cf-',
+                'manifest.dpkg',
+                'manifest.dpkg.built-using',
+                'manifest.deb822.gz',
+            ], stdout=untar.stdin)
+            self.assertEqual(tar.wait(), 0)
+            self.assertEqual(untar.wait(), 0)
+
+    def test_other(self):
+        subprocess.check_call([
+            SETUP_CHROOT,
+            '--i386',
+            '--beta',
+            '--output-dir', '/opt',
+        ])
+        self.assertTrue(
+            os.path.exists(
+                '/opt/steamrt_scout_beta_i386/etc/debian_chroot'))
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_beta_i386',
+            '--',
+            'uname', '-m',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'i686\n')
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_beta_i386',
+            '--',
+            'dpkg', '--print-architecture',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'i386\n')
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_beta_i386',
+            '--',
+            'cat', '/etc/debian_chroot',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'steamrt_scout_beta_i386\n')
+
+        output = subprocess.check_output([
+            'schroot',
+            '-c', 'steamrt_scout_beta_i386',
+            '--',
+            'readlink', '-f', '/usr/bin/gcc'
+        ], universal_newlines=True)
+        self.assertEqual(output, '/usr/bin/gcc-4.8\n')
+
+        artifacts = os.getenv('AUTOPKGTEST_ARTIFACTS')
+
+        if artifacts is not None:
+            os.makedirs(os.path.join(artifacts, 'schroot', 'i386-beta'))
+
+            untar = subprocess.Popen([
+                'tar', '-C', os.path.join(artifacts, 'schroot', 'i386-beta'),
+                '-xf-',
+            ], stdin=subprocess.PIPE)
+            tar = subprocess.Popen([
+                'schroot',
+                '-c', 'steamrt_scout_beta_i386',
+                '--',
+                'tar', '-C', '/usr',
+                '-cf-',
+                'manifest.dpkg',
+                'manifest.dpkg.built-using',
+                'manifest.deb822.gz',
+            ], stdout=untar.stdin)
+            self.assertEqual(tar.wait(), 0)
+            self.assertEqual(untar.wait(), 0)
+
+    def tearDown(self):
+        # type: () -> None
+        pass
+
+
+if __name__ == '__main__':
+    if sys.argv[1:2] == ['--no-reexec']:
+        sys.argv[1:] = sys.argv[2:]
+    elif os.getuid() == 0:
+        normal_user = os.getenv('AUTOPKGTEST_NORMAL_USER')
+
+        if normal_user is None:
+            print('1..0 # SKIP Normal user required')
+            sys.exit(0)
+
+        subprocess.check_call(['adduser', normal_user, 'sudo'])
+        env = []
+        for var in (
+            'AUTOPKGTEST_ARTIFACTS', 'AUTOPKGTEST_NORMAL_USER',
+            'AUTOPKGTEST_REBOOT_MARK', 'AUTOPKGTEST_TMP',
+            'http_proxy', 'https_proxy', 'no_proxy',
+        ):
+            if var in os.environ:
+                env.append('%s=%s' % (var, os.getenv(var)))
+        os.execvp(
+            'runuser',
+            [
+                'runuser',
+                '--login',
+                '--shell=/bin/sh',
+                '-c', 'exec "$@"',
+                normal_user,
+                '--',
+                'sh',   # argv[0]
+                'env',
+            ] + env + [
+                __file__,
+                '--no-reexec',
+            ] + sys.argv[1:],
+        )
+
+    sys.path[:0] = [
+        os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            os.pardir,
+            'tests',
+            'third-party',
+        )
+    ]
+    from pycotap import TAPTestRunner
+    unittest.main(verbosity=2, testRunner=TAPTestRunner)
+
+# vi: set sw=4 sts=4 et:

--- a/debian/tests/setup-docker.py
+++ b/debian/tests/setup-docker.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# Copyright 2019 Collabora Ltd.
+#
+# SPDX-License-Identifier: MIT
+# (see build-runtime.py)
+
+from __future__ import print_function
+
+import os
+import os.path
+import subprocess
+import sys
+import unittest
+
+try:
+    import typing
+    typing      # silence pyflakes
+except ImportError:
+    pass
+
+
+SETUP_DOCKER = os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    os.pardir,
+    'setup_docker.sh',
+)
+
+EXTRA_BOOTSTRAP = os.path.join(
+    os.path.dirname(__file__),
+    'extra-bootstrap.sh',
+)
+
+
+class TestBuildRuntime(unittest.TestCase):
+    def setUp(self):
+        # type: () -> None
+        pass
+
+    def test_default(self):
+        # Send stdout to our stderr to avoid interfering with TAP.
+        # Use fd 2 directly because pycotap reopens sys.stdout, sys.stderr
+        subprocess.check_call([
+            SETUP_DOCKER,
+            'amd64',
+        ], stdout=2, stderr=2)
+
+        output = subprocess.check_output([
+            'docker', 'run',
+            '--rm', '--init',
+            'steam-runtime-amd64',
+            '/dev/init', '-sg',
+            '--',
+            'uname', '-m',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'x86_64\n')
+
+        output = subprocess.check_output([
+            'docker', 'run',
+            '--rm', '--init',
+            'steam-runtime-amd64',
+            '/dev/init', '-sg',
+            '--',
+            'dpkg', '--print-architecture',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'amd64\n')
+
+        output = subprocess.check_output([
+            'docker', 'run',
+            '--rm', '--init',
+            'steam-runtime-amd64',
+            '/dev/init', '-sg',
+            '--',
+            'readlink', '-f', '/usr/bin/gcc'
+        ], universal_newlines=True)
+        self.assertEqual(output, '/usr/bin/gcc-4.8\n')
+
+        artifacts = os.getenv('AUTOPKGTEST_ARTIFACTS')
+
+        if artifacts is not None:
+            os.makedirs(os.path.join(artifacts, 'docker', 'amd64'))
+
+            untar = subprocess.Popen([
+                'tar', '-C', os.path.join(artifacts, 'docker', 'amd64'),
+                '-xf-',
+            ], stdin=subprocess.PIPE)
+            tar = subprocess.Popen([
+                'docker', 'run', '--rm', '--init',
+                'steam-runtime-amd64',
+                '/dev/init', '-sg',
+                '--',
+                'tar', '-C', '/usr',
+                '-cf-',
+                'manifest.dpkg',
+                'manifest.dpkg.built-using',
+                'manifest.deb822.gz',
+            ], stdout=untar.stdin)
+            self.assertEqual(tar.wait(), 0)
+            self.assertEqual(untar.wait(), 0)
+
+    def test_other(self):
+        subprocess.check_call([
+            SETUP_DOCKER,
+            '--beta',
+            '--extra-bootstrap', EXTRA_BOOTSTRAP,
+            'i386',
+        ])
+
+        output = subprocess.check_output([
+            'docker', 'run',
+            '--rm', '--init',
+            'steam-runtime-i386-beta',
+            '/dev/init', '-sg',
+            '--',
+            'dpkg', '--print-architecture',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'i386\n')
+
+        output = subprocess.check_output([
+            'docker', 'run',
+            '--rm', '--init',
+            'steam-runtime-i386-beta',
+            '/dev/init', '-sg',
+            '--',
+            'readlink', '-f', '/usr/bin/gcc'
+        ], universal_newlines=True)
+        self.assertEqual(output, '/usr/bin/gcc-4.8\n')
+
+        output = subprocess.check_output([
+            'docker', 'run',
+            '--rm', '--init',
+            'steam-runtime-i386-beta',
+            '/dev/init', '-sg',
+            '--',
+            'cat', '/etc/debian_chroot',
+        ], universal_newlines=True)
+        self.assertEqual(output, 'Docker\n')
+
+        artifacts = os.getenv('AUTOPKGTEST_ARTIFACTS')
+
+        if artifacts is not None:
+            os.makedirs(os.path.join(artifacts, 'docker', 'i386-beta'))
+
+            untar = subprocess.Popen([
+                'tar', '-C', os.path.join(artifacts, 'docker', 'i386-beta'),
+                '-xf-',
+            ], stdin=subprocess.PIPE)
+            tar = subprocess.Popen([
+                'docker', 'run', '--rm', '--init',
+                'steam-runtime-i386-beta',
+                '/dev/init', '-sg',
+                '--',
+                'tar', '-C', '/usr',
+                '-cf-',
+                'manifest.dpkg',
+                'manifest.dpkg.built-using',
+                'manifest.deb822.gz',
+            ], stdout=untar.stdin)
+            self.assertEqual(tar.wait(), 0)
+            self.assertEqual(untar.wait(), 0)
+
+    def tearDown(self):
+        # type: () -> None
+        pass
+
+
+if __name__ == '__main__':
+    if sys.argv[1:2] == ['--no-reexec']:
+        sys.argv[1:] = sys.argv[2:]
+    elif os.getuid() == 0:
+        normal_user = os.getenv('AUTOPKGTEST_NORMAL_USER')
+
+        if normal_user is None:
+            print('1..0 # SKIP Normal user required')
+            sys.exit(0)
+
+        subprocess.check_call(['adduser', normal_user, 'sudo'])
+        subprocess.check_call(['adduser', normal_user, 'docker'])
+        env = []
+        for var in (
+            'AUTOPKGTEST_ARTIFACTS', 'AUTOPKGTEST_NORMAL_USER',
+            'AUTOPKGTEST_REBOOT_MARK', 'AUTOPKGTEST_TMP',
+            'http_proxy', 'https_proxy', 'no_proxy',
+        ):
+            if var in os.environ:
+                env.append('%s=%s' % (var, os.getenv(var)))
+        os.execvp(
+            'runuser',
+            [
+                'runuser',
+                '--login',
+                '--shell=/bin/sh',
+                '-c', 'exec "$@"',
+                normal_user,
+                '--',
+                'sh',   # argv[0]
+                'env',
+            ] + env + [
+                __file__,
+                '--no-reexec',
+            ] + sys.argv[1:],
+        )
+
+    sys.path[:0] = [
+        os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            os.pardir,
+            'tests',
+            'third-party',
+        )
+    ]
+    from pycotap import TAPTestRunner
+    unittest.main(verbosity=2, testRunner=TAPTestRunner)
+
+# vi: set sw=4 sts=4 et:

--- a/scripts/bootstrap-runtime.sh
+++ b/scripts/bootstrap-runtime.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-COLOR_OFF="\033[0m"
-COLOR_ON="\033[1;93m"
+COLOR_OFF='\033[0m'
+COLOR_ON='\033[1;93m'
 
 set -eu
 
@@ -30,6 +30,9 @@ bootstrap_container()
   # Load proxy settings, if any
   if [ -f /etc/profile.d/steamrtproj.sh ]; then
     # Read in our envar proxy settings (needed for wget).
+    # This is a file inside the container so we can't follow the 'source'
+    # for shellcheck:
+    # shellcheck disable=SC1091
     source /etc/profile.d/steamrtproj.sh
   fi
 
@@ -183,8 +186,8 @@ heredoc
   update-alternatives --set cpp-bin /usr/bin/cpp-4.8
 
   # Allow members of sudo group sudo to run in runtime without password prompt
-  echo -e "\n${COLOR_ON}Allow members of sudo group to run sudo in runtime without prompting for password...${COLOR_OFF}"
-  echo -e "# Allow members of group sudo to execute any command\n%sudo   ALL= NOPASSWD: ALL\n" > /etc/sudoers.d/nopassword
+  echo -e "\\n${COLOR_ON}Allow members of sudo group to run sudo in runtime without prompting for password...${COLOR_OFF}"
+  echo -e "# Allow members of group sudo to execute any command\\n%sudo   ALL= NOPASSWD: ALL\\n" > /etc/sudoers.d/nopassword
   chmod 440 /etc/sudoers.d/nopassword
 
   # Remove downloaded packages: we won't need to install them again

--- a/setup_chroot.sh
+++ b/setup_chroot.sh
@@ -23,25 +23,32 @@ if [[ $(tput colors 2>/dev/null || echo 0) -gt 0 ]]; then
   COLOR_OFF=$'\e[0m'
 fi
 
-sh_quote() { local quoted="$(printf '%q ' "$@")"; [[ $# -eq 0 ]] || echo "${quoted:0:-1}"; }
+sh_quote ()
+{
+  local quoted
+  if [ $# -gt 0 ]; then
+    quoted="$(printf '%q ' "$@")"
+    echo "${quoted:0:-1}"
+  fi
+}
 
 prebuild_chroot()
 {
 	# install some packages
-	echo -e "\n${COLOR_ON}Installing debootstrap schroot...${COLOR_OFF}"
+	echo -e "\\n${COLOR_ON}Installing debootstrap schroot...${COLOR_OFF}"
 	sudo -E apt-get install -y debootstrap schroot
 
 	# Check if there are any active schroot sessions right now and warn if so...
 	schroot_list=$(schroot --list --all-sessions | head -n 1)
-	if [ $schroot_list ]; then
+	if [ -n "$schroot_list" ]; then
 		tput setaf 3
-		echo -e "\nWARNING: Schroot says you have a currently active session!\n"
+		echo -e "\\nWARNING: Schroot says you have a currently active session!\\n"
 		tput sgr0
 		echo "  ${schroot_list}"
 		echo ""
-		read -p "Are you sure you want to continue (y/n)? "
+		read -r -p "Are you sure you want to continue (y/n)? "
 		if [[ "$REPLY" != [Yy] ]]; then
-			echo -e "Cancelled...\n"
+			echo -e "Cancelled...\\n"
 			exit 1
 		fi
 	fi
@@ -58,9 +65,9 @@ prebuild_chroot()
 	done
 
 	if [[ "$STEAM_RUNTIME_SPEW_WARNING" == "1" ]]; then
-		read -p "  This ok (y/n)? "
+		read -r -p "  This ok (y/n)? "
 		if [[ "$REPLY" != [Yy] ]]; then
-			echo -e "Cancelled...\n"
+			echo -e "Cancelled...\\n"
 			exit 1
 		fi
 	fi
@@ -97,20 +104,20 @@ build_chroot()
 	CHROOT_NAME=${CHROOT_PREFIX}${pkg}
 
 	# blow away existing directories and recreate empty ones
-	echo -e "\n${COLOR_ON}Creating ${CHROOT_DIR}/${CHROOT_NAME}..."
+	echo -e "\\n${COLOR_ON}Creating ${CHROOT_DIR}/${CHROOT_NAME}..."
 	sudo rm -rf "${CHROOT_DIR}/${CHROOT_NAME}"
 	sudo mkdir -p "${CHROOT_DIR}/${CHROOT_NAME}"
 
 	# Create our schroot .conf file
-	echo -e "\n${COLOR_ON}Creating /etc/schroot/chroot.d/${CHROOT_NAME}.conf...${COLOR_OFF}" 
-	printf "[${CHROOT_NAME}]\ndescription=Ubuntu 12.04 Precise for ${pkg}\ndirectory=${CHROOT_DIR}/${CHROOT_NAME}\npersonality=${personality}\ngroups=sudo\nroot-groups=sudo\npreserve-environment=true\ntype=directory\n" | sudo tee /etc/schroot/chroot.d/${CHROOT_NAME}.conf
+	echo -e "\\n${COLOR_ON}Creating /etc/schroot/chroot.d/${CHROOT_NAME}.conf...${COLOR_OFF}"
+	printf '[%s]\ndescription=Ubuntu 12.04 Precise for %s\ndirectory=%s/%s\npersonality=%s\ngroups=sudo\nroot-groups=sudo\npreserve-environment=true\ntype=directory\n' "${CHROOT_NAME}" "${pkg}" "${CHROOT_DIR}" "${CHROOT_NAME}" "${personality}" | sudo tee "/etc/schroot/chroot.d/${CHROOT_NAME}.conf"
 
 	# Create our chroot
-	echo -e "\n${COLOR_ON}Bootstrap the chroot...${COLOR_OFF}" 
-	sudo -E debootstrap --arch=${pkg} --include=wget --keyring="${SCRIPT_DIR}/ubuntu-archive-keyring.gpg" precise ${CHROOT_DIR}/${CHROOT_NAME} http://archive.ubuntu.com/ubuntu/
+	echo -e "\\n${COLOR_ON}Bootstrap the chroot...${COLOR_OFF}"
+	sudo -E debootstrap --arch="${pkg}" --include=wget --keyring="${SCRIPT_DIR}/ubuntu-archive-keyring.gpg" precise "${CHROOT_DIR}/${CHROOT_NAME}" http://archive.ubuntu.com/ubuntu/
 
 	# Copy over proxy settings from host machine
-	echo -e "\n${COLOR_ON}Adding proxy info to chroot (if set)...${COLOR_OFF}"
+	echo -e "\\n${COLOR_ON}Adding proxy info to chroot (if set)...${COLOR_OFF}"
 	set +o pipefail
 	env | grep -i "_proxy=" | grep -v PERSISTENT_HISTORY_LAST | xargs -i echo export {} | sudo tee ${CHROOT_DIR}/${CHROOT_NAME}/etc/profile.d/steamrtproj.sh
 	env | grep -i "_proxy=" | grep -v PERSISTENT_HISTORY_LAST | xargs -i echo export {} | sudo tee -a ${CHROOT_DIR}/${CHROOT_NAME}/etc/environment
@@ -118,7 +125,7 @@ build_chroot()
 	sudo rm -rf "${CHROOT_DIR}/${CHROOT_NAME}/etc/apt/apt.conf"
 	if [ -f /etc/apt/apt.conf ]; then sudo cp "/etc/apt/apt.conf" "${CHROOT_DIR}/${CHROOT_NAME}/etc/apt"; fi  
 
-	echo -e "\n${COLOR_ON}Running ${BOOTSTRAP_SCRIPT}$(printf ' %q' "$@")...${COLOR_OFF}"
+	echo -e "\\n${COLOR_ON}Running ${BOOTSTRAP_SCRIPT}$(printf ' %q' "$@")...${COLOR_OFF}"
 
 	# Touch the logfile first so it has the proper permissions
 	rm -f "${LOGFILE}"
@@ -140,7 +147,7 @@ build_chroot()
 # http://stackoverflow.com/questions/64786/error-handling-in-bash
 function cleanup()
 {
-	echo -e "\nenv is:\n$(env)\n"
+	echo -e "\\nenv is:\\n$(env)\\n"
 	echo "ERROR: ${SCRIPTNAME} just hit error handler."
 	echo "  BASH_COMMAND is \"${BASH_COMMAND}\""
 	echo "  BASH_VERSION is $BASH_VERSION"
@@ -160,7 +167,7 @@ usage()
 	fi
 
 	echo "Usage: $0 [--beta | --suite SUITE] [--extra-apt-source 'deb http://MIRROR SUITE COMPONENT...'] [--output-dir <DIRNAME>] --i386 | --amd64"
-	exit $1
+	exit "$1"
 }
 
 main()
@@ -179,7 +186,7 @@ main()
 	while [ "$#" -gt 0 ]; do
 		case "$1" in
 			(--amd64|--i386)
-				arch_arguments+=($1)
+				arch_arguments+=("$1")
 				shift
 				;;
 
@@ -244,12 +251,12 @@ main()
 	done
 	trap - EXIT
 
-	echo -e "\n${COLOR_ON}Done...${COLOR_OFF}"
+	echo -e "\\n${COLOR_ON}Done...${COLOR_OFF}"
 }
 
 # Launch ourselves with script so we can time this and get a log file
 if [[ ! -v SETUP_CHROOT_LOGGING_STARTED ]]; then
-	if which script &>/dev/null; then
+	if command -v script >/dev/null; then
 		export SETUP_CHROOT_LOGGING_STARTED=1
 		export SHELL=/bin/bash
 		script --return --command "time $SCRIPT $(sh_quote "$@")" "${LOGFILE}"

--- a/setup_docker.sh
+++ b/setup_docker.sh
@@ -52,7 +52,8 @@ docker_haveimage() {
   showcmd sudo docker inspect "$1"
   # Echo y/n based on docker return, so we don't interpret the sudo command failing as the
   # docker-inspect returning negatively
-  local ret=$(sudo sh -c "$(sh_quote docker inspect "$1") &>/dev/null && echo y || echo n")
+  local ret
+  ret=$(sudo sh -c "$(sh_quote docker inspect "$1") &>/dev/null && echo y || echo n")
   [[ -n $ret ]] || die "sudo failure"
   [[ $ret = y ]] || return 1
 }

--- a/setup_docker.sh
+++ b/setup_docker.sh
@@ -27,7 +27,13 @@ if [[ $(tput colors 2>/dev/null || echo 0) -gt 0 ]]; then
   COLOR_CLEAR=$'\e[0m'
 fi
 
-sh_quote() { local quoted="$(printf '%q ' "$@")"; [[ $# -eq 0 ]] || echo $quoted; }
+sh_quote ()
+{
+  if [ $# -gt 0 ]; then
+    printf '%q ' "$@"
+  fi
+}
+
 err()      { echo >&2 "${COLOR_ERR}!!${COLOR_CLEAR} $*"; }
 stat()     { echo >&2 "${COLOR_STAT}::${COLOR_CLEAR} $*"; }
 showcmd()  { echo >&2 "+ ${COLOR_CMD}$(sh_quote "$@")${COLOR_CLEAR}"; }

--- a/templates/run.sh
+++ b/templates/run.sh
@@ -23,7 +23,7 @@ if [ "${STEAM_RUNTIME_PREFER_HOST_LIBRARIES-}" != "0" ]; then
         # If line starts with a leading / and contains :, it's a new path prefix
         if [[ "$line" =~ ^/.*: ]]
         then
-            library_path_prefix=`echo $line | cut -d: -f1`
+            library_path_prefix=$(echo $line | cut -d: -f1)
 
             host_library_paths=$host_library_paths$library_path_prefix:
         fi

--- a/templates/run.sh
+++ b/templates/run.sh
@@ -3,7 +3,7 @@
 # This is a script which runs programs in the Steam runtime
 
 # The top level of the runtime tree
-TOP=$(cd "${0%/*}" && echo ${PWD})
+TOP=$(cd "${0%/*}" && pwd)
 
 # Make sure we have something to run
 if [ "$1" = "" ]; then

--- a/templates/run.sh
+++ b/templates/run.sh
@@ -23,7 +23,7 @@ if [ "${STEAM_RUNTIME_PREFER_HOST_LIBRARIES-}" != "0" ]; then
         # If line starts with a leading / and contains :, it's a new path prefix
         if [[ "$line" =~ ^/.*: ]]
         then
-            library_path_prefix=$(echo $line | cut -d: -f1)
+            library_path_prefix=$(echo "$line" | cut -d: -f1)
 
             host_library_paths=$host_library_paths$library_path_prefix:
         fi

--- a/templates/run.sh
+++ b/templates/run.sh
@@ -17,19 +17,19 @@ fi
 export STEAM_RUNTIME="${TOP}"
 
 host_library_paths=
-		
+
 if [ "${STEAM_RUNTIME_PREFER_HOST_LIBRARIES-}" != "0" ]; then
-	while read -r line; do
-		# If line starts with a leading / and contains :, it's a new path prefix
-		if [[ "$line" =~ ^/.*: ]]
-		then
-			library_path_prefix=`echo $line | cut -d: -f1`
-	
-			host_library_paths=$host_library_paths$library_path_prefix:
-		fi
-	done <<< "$(/sbin/ldconfig -XNv 2> /dev/null)"
-	
-	host_library_paths="$STEAM_RUNTIME/pinned_libs_32:$STEAM_RUNTIME/pinned_libs_64:$host_library_paths"
+    while read -r line; do
+        # If line starts with a leading / and contains :, it's a new path prefix
+        if [[ "$line" =~ ^/.*: ]]
+        then
+            library_path_prefix=`echo $line | cut -d: -f1`
+
+            host_library_paths=$host_library_paths$library_path_prefix:
+        fi
+    done <<< "$(/sbin/ldconfig -XNv 2> /dev/null)"
+
+    host_library_paths="$STEAM_RUNTIME/pinned_libs_32:$STEAM_RUNTIME/pinned_libs_64:$host_library_paths"
 fi
 
 steam_runtime_library_paths="$host_library_paths$STEAM_RUNTIME/i386/lib/i386-linux-gnu:$STEAM_RUNTIME/i386/lib:$STEAM_RUNTIME/i386/usr/lib/i386-linux-gnu:$STEAM_RUNTIME/i386/usr/lib:$STEAM_RUNTIME/amd64/lib/x86_64-linux-gnu:$STEAM_RUNTIME/amd64/lib:$STEAM_RUNTIME/amd64/usr/lib/x86_64-linux-gnu:$STEAM_RUNTIME/amd64/usr/lib"

--- a/tests/mypy.sh
+++ b/tests/mypy.sh
@@ -21,7 +21,7 @@ for script in \
             --python-executable="${PYTHON:=python3}" \
             --follow-imports=skip \
             --ignore-missing-imports \
-            $script; then
+            "$script"; then
         echo "ok $i - $script"
     else
         echo "not ok $i - $script # TODO mypy issues reported"

--- a/tests/mypy.sh
+++ b/tests/mypy.sh
@@ -12,6 +12,7 @@ export MYPYPATH="${PYTHONPATH:=$(pwd)}"
 
 i=0
 for script in \
+    debian/tests/*.py \
     tests/*.py \
 ; do
     i=$((i + 1))

--- a/tests/pycodestyle.sh
+++ b/tests/pycodestyle.sh
@@ -26,6 +26,7 @@ else
 fi
 
 if "${PYCODESTYLE}" \
+    debian/tests/*.py \
     tests/*.py \
     >&2; then
     echo "ok 2 - $PYCODESTYLE reported no issues"

--- a/tests/pyflakes.sh
+++ b/tests/pyflakes.sh
@@ -13,6 +13,7 @@ if [ "x${PYFLAKES:=pyflakes3}" = xfalse ] || \
     echo "1..0 # SKIP pyflakes3 not found"
 elif "${PYFLAKES}" \
     ./*.py \
+    debian/tests/*.py \
     tests/*.py \
     >&2; then
     echo "1..1"

--- a/tests/pyflakes.sh
+++ b/tests/pyflakes.sh
@@ -12,7 +12,7 @@ if [ "x${PYFLAKES:=pyflakes3}" = xfalse ] || \
         [ -z "$(command -v "$PYFLAKES")" ]; then
     echo "1..0 # SKIP pyflakes3 not found"
 elif "${PYFLAKES}" \
-    *.py \
+    ./*.py \
     tests/*.py \
     >&2; then
     echo "1..1"

--- a/tests/shellcheck.sh
+++ b/tests/shellcheck.sh
@@ -14,6 +14,7 @@ fi
 
 n=0
 for shell_script in \
+        scripts/*.sh \
         tests/*.sh \
         templates/*.sh \
         ; do

--- a/tests/shellcheck.sh
+++ b/tests/shellcheck.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Copyright © 2018-2019 Collabora Ltd
+#
+# SPDX-License-Identifier: MIT
+# (See build-runtime.py)
+
+set -e
+set -u
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "1..0 # SKIP shellcheck not available"
+    exit 0
+fi
+
+n=0
+for shell_script in \
+        tests/*.sh \
+        templates/*.sh \
+        ; do
+    n=$((n + 1))
+    if shellcheck "$shell_script"; then
+        echo "ok $n - $shell_script"
+    else
+        echo "not ok $n # TODO - $shell_script"
+    fi
+done
+
+echo "1..$n"

--- a/tests/third-party/pycotap.py
+++ b/tests/third-party/pycotap.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright (c) 2015 Remko Tronçon (https://el-tramo.be)
+# Released under the MIT license
+# See COPYING for details
+
+
+import unittest
+import sys
+import base64
+if sys.hexversion >= 0x03000000:
+  from io import StringIO
+else:
+  from StringIO import StringIO
+
+# Log modes
+class LogMode(object) :
+  LogToError, LogToDiagnostics, LogToYAML, LogToAttachment = range(4)
+
+
+class TAPTestResult(unittest.TestResult):
+  def __init__(self, output_stream, error_stream, message_log, test_output_log):
+    super(TAPTestResult, self).__init__(self, output_stream)
+    self.output_stream = output_stream
+    self.error_stream = error_stream
+    self.orig_stdout = None
+    self.orig_stderr = None
+    self.message = None
+    self.test_output = None
+    self.message_log = message_log
+    self.test_output_log = test_output_log
+    self.output_stream.write("TAP version 13\n")
+    self._set_streams()
+
+  def printErrors(self):
+    self.print_raw("1..%d\n" % self.testsRun)
+    self._reset_streams()
+
+  def _set_streams(self):
+    self.orig_stdout = sys.stdout
+    self.orig_stderr = sys.stderr
+    if self.message_log == LogMode.LogToError:
+      self.message = self.error_stream
+    else:
+      self.message = StringIO()
+    if self.test_output_log == LogMode.LogToError:
+      self.test_output = self.error_stream
+    else:
+      self.test_output = StringIO()
+
+    if self.message_log == self.test_output_log:
+      self.test_output = self.message
+    sys.stdout = sys.stderr = self.test_output
+
+  def _reset_streams(self):
+    sys.stdout = self.orig_stdout
+    sys.stderr = self.orig_stderr
+
+
+  def print_raw(self, text):
+    self.output_stream.write(text)
+    self.output_stream.flush()
+
+  def print_result(self, result, test, directive = None):
+    self.output_stream.write("%s %d %s" % (result, self.testsRun, test.id()))
+    if directive:
+      self.output_stream.write(" # " + directive)
+    self.output_stream.write("\n")
+    self.output_stream.flush()
+
+  def ok(self, test, directive = None):
+    self.print_result("ok", test, directive)
+
+  def not_ok(self, test):
+    self.print_result("not ok", test)
+
+  def startTest(self, test):
+    super(TAPTestResult, self).startTest(test)
+
+  def stopTest(self, test):
+    super(TAPTestResult, self).stopTest(test)
+    if self.message_log == self.test_output_log:
+      logs = [(self.message_log, self.message, "output")]
+    else:
+      logs = [
+          (self.test_output_log, self.test_output, "test_output"),
+          (self.message_log, self.message, "message")
+      ]
+    for log_mode, log, log_name in logs:
+      if log_mode != LogMode.LogToError:
+        output = log.getvalue()
+        if len(output):
+          if log_mode == LogMode.LogToYAML:
+            self.print_raw("  ---\n")
+            self.print_raw("    " + log_name + ": |\n")
+            self.print_raw("      " + output.rstrip().replace("\n", "\n      ") + "\n")
+            self.print_raw("  ...\n")
+          elif log_mode == LogMode.LogToAttachment:
+            self.print_raw("  ---\n")
+            self.print_raw("    " + log_name + ":\n")
+            self.print_raw("      File-Name: " + log_name + ".txt\n")
+            self.print_raw("      File-Type: text/plain\n")
+            self.print_raw("      File-Content: " + base64.b64encode(output) + "\n")
+            self.print_raw("  ...\n")
+          else:
+            self.print_raw("# " + output.rstrip().replace("\n", "\n# ") + "\n")
+        log.truncate(0)
+
+  def addSuccess(self, test):
+    super(TAPTestResult, self).addSuccess(test)
+    self.ok(test)
+
+  def addError(self, test, err):
+    super(TAPTestResult, self).addError(test, err)
+    self.message.write(self.errors[-1][1] + "\n")
+    self.not_ok(test)
+
+  def addFailure(self, test, err):
+    super(TAPTestResult, self).addFailure(test, err)
+    self.message.write(self.failures[-1][1] + "\n")
+    self.not_ok(test)
+
+  def addSkip(self, test, reason):
+    super(TAPTestResult, self).addSkip(test, reason)
+    self.ok(test, "SKIP " + reason)
+
+  def addExpectedFailure(self, test, err):
+    super(TAPTestResult, self).addExpectedFailure(test, err)
+    self.ok(test)
+
+  def addUnexpectedSuccess(self, test):
+    super(TAPTestResult, self).addUnexpectedSuccess(test)
+    self.message.write("Unexpected success" + "\n")
+    self.not_ok(test)
+
+
+class TAPTestRunner(object):
+  def __init__(self, 
+      message_log = LogMode.LogToYAML,
+      test_output_log = LogMode.LogToDiagnostics, 
+      output_stream = sys.stdout, error_stream = sys.stderr):
+    self.output_stream = output_stream
+    self.error_stream = error_stream
+    self.message_log = message_log
+    self.test_output_log = test_output_log
+
+  def run(self, test):
+    result = TAPTestResult(
+        self.output_stream, 
+        self.error_stream, 
+        self.message_log, 
+        self.test_output_log)
+    test(result)
+    result.printErrors()
+
+    return result


### PR DESCRIPTION
This branch continues from #150, so please review that one first (or I can rebase this one if maintainers would prefer to merge it first).

It adds [shellcheck](https://www.shellcheck.net/) coverage for various shell scripts. `shellcheck` is a lint tool for Bourne shell and bash scripts which detects various common mistakes, particularly around code that would go wrong if filenames and other strings contain spaces.