### PR TITLE
Add setup.sh to script templates

### DIFF
--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Copyright 2019 Collabora Ltd.
+#
+# SPDX-License-Identifier: MIT
+
+set -e
+set -u
+set -o pipefail
+
+pin_newer_runtime_libs ()
+{
+    echo "TODO: update pins for $1" >&2
+    exit 1
+}
+
+check_pins ()
+{
+    echo "TODO: check pins for $1" >&2
+    exit 1
+}
+
+usage ()
+{
+    local status="${1:-2}"
+
+    if [ "${status}" -gt 0 ]; then
+        exec >&2
+    fi
+
+    cat << EOF
+Usage: $me [OPTIONS...] [ACTION]
+
+Set up the Steam Runtime in preparation for running games or other
+programs using its libraries.
+
+Options:
+--force                         Always update pinned libraries from the
+                                host system, even if it does not appear
+                                necessary.
+
+Actions:
+--help                          Print this help
+--print-bin-path                Print the entries to prepend to PATH when
+                                running in this Steam Runtime
+EOF
+
+    exit "$status"
+}
+
+main ()
+{
+    local me="$0"
+    local top
+    top="$(cd "${0%/*}"; pwd)"
+    local arch
+    local getopt_temp
+
+    local action="setup"
+    local opt_force=
+
+    getopt_temp="help"
+    getopt_temp="${getopt_temp},force"
+    getopt_temp="${getopt_temp},print-bin-path"
+
+    getopt_temp="$(getopt -o '' --long "$getopt_temp" -n "$me" -- "$@")"
+    eval "set -- $getopt_temp"
+    unset getopt_temp
+
+    while [ "$#" -gt 0 ]
+    do
+        case "$1" in
+            (--help)
+                usage 0
+                ;;
+
+            (--force)
+                opt_force=yes
+                shift
+                ;;
+
+            (--print-bin-path)
+                action="$1"
+                shift
+                ;;
+
+            (--print-lib-paths)
+                action="$1"
+                shift
+                ;;
+
+            (--)
+                shift
+                break
+                ;;
+
+            (-*)
+                echo "$me: unknown option: $1" >&2
+                usage 2
+                ;;
+
+            (*)
+                break
+                ;;
+        esac
+    done
+
+    if [ "$#" -gt 0 ]
+    then
+        echo "$me does not have positional parameters" >&2
+        usage 2
+    fi
+
+    case "$action" in
+        (--print-bin-path)
+            case "$(uname -m)" in
+                (*64)
+                    arch=amd64
+                    ;;
+                (*)
+                    arch=i386
+                    ;;
+            esac
+            echo "$top/$arch/bin:$top/$arch/usr/bin"
+            ;;
+
+        (setup)
+            if [ -n "$opt_force" ]
+            then
+                pin_newer_runtime_libs "$top"
+            else
+                check_pins "$top"
+            fi
+            ;;
+    esac
+}
+
+main "$@"
+
+# vim:set sw=4 sts=4 et:

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -14,14 +14,35 @@ pin_newer_runtime_libs ()
     local IFS
     IFS=$(echo -en '\n\b')
 
+    local steam_runtime_path
+
     # First argument is the runtime path
     steam_runtime_path=$(realpath "$1")
 
     if [[ ! -d "$steam_runtime_path" ]]; then return; fi
 
     # Associative array; indices are the SONAME, values are final path
-    declare -A host_libraries_32
-    declare -A host_libraries_64
+    local -A host_libraries_32
+    local -A host_libraries_64
+
+    local bitness
+    local final_library
+    local find_output
+    local h_lib_major
+    local h_lib_minor
+    local h_lib_third
+    local host_library
+    local host_soname_symlink
+    local ldconfig_output
+    local leftside
+    local library_path_prefix
+    local r_lib_major
+    local r_lib_minor
+    local r_lib_third
+    local runtime_version_newer
+    local soname
+    local soname_fullpath
+    local soname_symlink
 
     rm -rf "$steam_runtime_path/pinned_libs_32"
     rm -rf "$steam_runtime_path/pinned_libs_64"
@@ -176,6 +197,12 @@ check_pins ()
     # Set separator to newline just for this function
     local IFS
     IFS=$(echo -en '\n\b')
+
+    local host_actual_library
+    local host_library
+    local host_sonamesymlink
+    local pins_need_redoing
+    local steam_runtime_path
 
     # First argument is the runtime path
     steam_runtime_path=$(realpath "$1")

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -171,18 +171,24 @@ pin_newer_runtime_libs ()
                     "$soname" == "libdbusmenu-glib.so.4" || \
                     "$soname" == "libdbus-1.so.3" ]]
             then
-                runtime_version_newer="yes"
+                runtime_version_newer="forced"
             fi
         fi
 
         if [[ "$soname" == "libSDL2-2.0.so.0" ]]
         then
-            runtime_version_newer="yes"
+            runtime_version_newer="forced"
         fi
 
 
         if [[ $runtime_version_newer == "yes" ]]; then
             echo "Found newer runtime version for $bitness-bit $soname. Host: $h_lib_major.$h_lib_minor.$h_lib_third Runtime: $r_lib_major.$r_lib_minor.$r_lib_third"
+        elif [[ $runtime_version_newer == "forced" ]]; then
+            echo "Forced use of runtime version for $bitness-bit $soname. Host: $h_lib_major.$h_lib_minor.$h_lib_third Runtime: $r_lib_major.$r_lib_minor.$r_lib_third"
+        fi
+
+        if [[ $runtime_version_newer == "yes" \
+              || $runtime_version_newer == "forced" ]]; then
             ln -s "$final_library" "$steam_runtime_path/pinned_libs_$bitness/$soname"
             # Keep track of the exact version name we saw on the system at pinning time to check later
             echo "$host_soname_symlink" > "$steam_runtime_path/pinned_libs_$bitness/system_$soname"

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -240,12 +240,14 @@ check_pins ()
             if ! host_actual_library=$(readlink -f "$host_sonamesymlink")
             then
                 pins_need_redoing="yes"
+                break
             fi
 
             # It might not exist anymore if it got uninstalled or upgraded to a different major version
             if [[ ! -f $host_actual_library ]]
             then
                 pins_need_redoing="yes"
+                break
             fi
 
             # We should end up at the same lib we saved in the second line
@@ -253,6 +255,7 @@ check_pins ()
             then
                 # Mismatch, it could have gotten upgraded
                 pins_need_redoing="yes"
+                break
             fi
         done
     fi

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -66,7 +66,10 @@ pin_newer_runtime_libs ()
             # Left-hand side of soname symlink should be *.so.%d
             if [[ ! $soname_fullpath =~ .*\.so.[[:digit:]]+$ ]]; then continue; fi
 
-            final_library=$(readlink -f "$soname_fullpath")
+            if ! final_library=$(readlink -f "$soname_fullpath")
+            then
+                continue
+            fi
 
             # Target library must be named *.so.%d.%d.%d
             if [[ ! $final_library =~ .*\.so.[[:digit:]]+.[[:digit:]]+.[[:digit:]]+$ ]]; then continue; fi
@@ -95,7 +98,10 @@ pin_newer_runtime_libs ()
 
         soname_symlink=$find_output
 
-        final_library=$(readlink -f "$soname_symlink")
+        if ! final_library=$(readlink -f "$soname_symlink")
+        then
+            continue
+        fi
 
         # Target library must be named *.so.%d.%d.%d
         if [[ ! $final_library =~ .*\.so.([[:digit:]]+).([[:digit:]]+).([[:digit:]]+)$ ]]; then continue; fi
@@ -231,7 +237,10 @@ check_pins ()
             host_library=$(tail -1 "$pin")
 
             # Follow the host SONAME symlink we saved in the first line of the pin entry
-            host_actual_library=$(readlink -f "$host_sonamesymlink")
+            if ! host_actual_library=$(readlink -f "$host_sonamesymlink")
+            then
+                pins_need_redoing="yes"
+            fi
 
             # It might not exist anymore if it got uninstalled or upgraded to a different major version
             if [[ ! -f $host_actual_library ]]


### PR DESCRIPTION
This branch adds `templates/setup.sh`, which becomes `./setup.sh` in a Steam Runtime tarball. It sets up the "pinned" libraries using code adapted from the Steam client's `steam.sh` (thanks to @TTimo for agreeing to relicense this). This makes the Steam Runtime more self-contained and less dependent on the Steam client. Previously, `templates/run.sh` knew how to use libraries that had been pinned by `steam.sh`, but the Steam Runtime relied on the Steam client to set up the pinning.

The purpose of the "pinned" libraries is to get the right precedence when using a mixture of host-system and Steam Runtime libraries. If the version in the Runtime is newer, we have to use it, because a game might depend on updated functionality (for example we have some very new audio decoder libraries in `scout` for use by SDL_mixer). However, if the version on the host system is newer, we have to use *that*, because the graphics driver could depend on the newer version (for example a recent Mesa version with LLVM-based shader support needs at least the libstdc++ version with which it was compiled, which might be from g++-8 in a recent distro, whereas the Steam Runtime's newest available libstdc++ is only from g++-5).