### PR TITLE
templates/setup.sh: Improve robustness of quoting

### DIFF
--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -123,14 +123,14 @@ pin_newer_runtime_libs ()
         # If we had entries in our arrays, get them
         if [[ $(file -L "$final_library") == *"32-bit"* ]]
         then
-            if [ ! -z ${host_libraries_32[$soname]+isset} ]
+            if [ ! -z "${host_libraries_32[$soname]+isset}" ]
             then
                 host_soname_symlink=${host_libraries_32[$soname]}
             fi
             bitness="32"
         elif [[ $(file -L "$final_library") == *"64-bit"* ]]
         then
-            if [ ! -z ${host_libraries_64[$soname]+isset} ]
+            if [ ! -z "${host_libraries_64[$soname]+isset}" ]
             then
                 host_soname_symlink=${host_libraries_64[$soname]}
             fi


### PR DESCRIPTION
The shellcheck in Debian 10 'buster' doesn't warn about this, but the
version in Debian 9 'stretch' does. The code does the right thing
either way (it expands to the equivalent of either `[ ! -z ]`, which
fails as desired, or `[ ! -z isset ]`, which succeeds as desired), but
it's more obviously correct if we quote it, turning the first case into
`[ ! -z "" ]` (which also fails, as desired).