### PR TITLE
Add some missing packages to webhelper/packages.txt

### DIFF
--- a/webhelper/packages.txt
+++ b/webhelper/packages.txt
@@ -21,7 +21,7 @@ pixman libpixman-1-0
 libpng libpng12-0
 libselinux libselinux1
 libthai libthai0
-libx11 libx11-6 libx11-xcb1
+libx11 libx11-6 libx11-xcb1 libx11-data
 libxau libxau6
 libxcb libxcb1 libxcb-render0 libxcb-shm0
 libxcomposite libxcomposite1

--- a/webhelper/packages.txt
+++ b/webhelper/packages.txt
@@ -35,4 +35,5 @@ libxrandr libxrandr2
 libxrender libxrender1
 libxss libxss1
 libxtst libxtst6
+sqlite3 libsqlite3-0
 zlib zlib1g

--- a/webhelper/packages.txt
+++ b/webhelper/packages.txt
@@ -9,7 +9,7 @@ expat libexpat1
 libffi libffi6
 fontconfig libfontconfig1
 freetype libfreetype6
-gcc-4.9 libgcc1
+gcc-4.9 gcc-4.9-base libgcc1
 glib2.0 libglib2.0-0
 graphite2 libgraphite2-3
 harfbuzz libharfbuzz0b


### PR DESCRIPTION
While working on a metapackage-based approach to package selection for the runtime tarball, I wrote some code to check that for every library in our runtime, we also ship each of its dependencies (with some exceptions for things that we expect to get from the host system, like libc6 and libgl1, and for things that are needed at install-time but not during use, like debconf).

This flagged a few dependencies that we are not currently installing:

* libnss3 depends on libsqlite3-0, which we can't count on being available in the host system. We should add it.

* libx1-6 depends on libx11-data, which is in the main runtime but not in the one for the webhelper. I don't know how necessary this really is, but the conservative thing to do would be to add it here.

* libgcc1 (built by src:gcc-4.9) depends on gcc-4.9-base, which contains copyright and licensing information for packages built by src:gcc-4.9 (including libgcc1).