### PR TITLE
Fix source code downloads

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -1073,7 +1073,7 @@ for source in apt_sources:
 				release_info['date'],
 				'%a, %d %b %Y %H:%M:%S %Z',
 			))
-		except ValueError:
+		except (KeyError, ValueError):
 			timestamps[source] = 0
 
 if 'SOURCE_DATE_EPOCH' in os.environ:

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -273,7 +273,11 @@ def download_file(file_url, file_path):
 	except OSError:
 		pass
 
-	urlretrieve(file_url, file_path)
+	try:
+		urlretrieve(file_url, file_path)
+	except Exception as e:
+		sys.stderr.write('Error downloading %s:\n' % file_url)
+		raise
 	return True
 
 

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -312,6 +312,12 @@ def install_sources(apt_sources, sourcelist):
 	# of completeness and download all of them.
 	for sp in source_packages:
 		p = sp.stanza['package']
+
+		# Skip packages with Extra-Source-Only: yes.
+		# These don't necessarily appear in the package pool.
+		if sp.stanza.get('Extra-Source-Only', 'no') == 'yes':
+			continue
+
 		if p in sourcelist:
 			if args.verbose:
 				print("DOWNLOADING SOURCE: %s" % p)


### PR DESCRIPTION
* Cope with a missing date in apt repositories' metadata.
* When download fails, log the URL before the error.
* In the EOL Debian jessie repository, several versions of gcc-4.9 appear in Sources with Extra-Source-Only: yes, but do not appear in the package pool. Ignore those versions when downloading source code, fixing the build of the 'heavy' runtime.