### PR TITLE
build-runtime: Add libelf1 to runtime if something depends on it

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -539,6 +539,7 @@ def accept_transitive_dependency(name):
 		'gcc-4.8-base',
 		'gcc-4.9-base',
 		'gcc-5-base',
+		'libelf1',
 		'libx11-data',
 	)
 


### PR DESCRIPTION
A future Steam Runtime will include libcapsule-tools-relocatable (at
least in the debug runtime) to manipulate shared libraries and shared
library dependencies, and that package depends on libelf1. libelf1
itself doesn't seem important enough to elevate it to part of the
Steam Runtime's guaranteed ABI.