### PR TITLE
build-runtime: Also look for debug symbols in normal Packages file

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -147,13 +147,9 @@ class AptSource:
 
 	def get_packages_urls(self, arch, dbgsym=False):
 		# type: (str, bool) -> typing.List[str]
+
 		if self.kind != 'deb':
 			return []
-
-		if dbgsym:
-			maybe_debug = 'debug/'
-		else:
-			maybe_debug = ''
 
 		if self.suite.endswith('/') and not self.components:
 			suite = self.suite
@@ -163,12 +159,23 @@ class AptSource:
 
 			return ['%s/%sPackages.gz' % (self.url, suite)]
 
-		return [
-			"%s/dists/%s/%s/%sbinary-%s/Packages.gz" % (
-				self.url, self.suite, component,
-				maybe_debug, arch)
-			for component in self.components
-		]
+		ret = []		# type: typing.List[str]
+
+		for component in self.components:
+			ret.append(
+				"%s/dists/%s/%s/binary-%s/Packages.gz" % (
+					self.url, self.suite, component,
+					arch)
+			)
+
+			if dbgsym:
+				ret.append(
+					"%s/dists/%s/%s/debug/binary-%s/Packages.gz" % (
+						self.url, self.suite,
+						component, arch)
+				)
+
+		return ret
 
 
 def parse_args():


### PR DESCRIPTION
In Ubuntu, automatic -dbgsym packages are generated with the .ddeb
extension.

The apt repositories currently available on
<http://repo.steampowered.com/> were built with a modified reprepro
originating from <https://bugs.debian.org/730572>, which diverts
ddebs to a pseudo-component like "main/debug", similar to the existing
handling of udebs. Most of the changes from #730572 were never accepted
into upstream reprepro.

To avoid maintaining a patched reprepro indefinitely, it might be a good
idea to change debhelper so it puts the -dbgsym packages in ordinary
.deb files. This change makes build-runtime look in both package lists
so that it can cope either way.

Signed-off-by: Simon McVittie <smcv@collabora.com>