### PR TITLE
build-runtime: Build the debug runtime from the 'main' component

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -1029,14 +1029,9 @@ if args.verbose:
 	for property, value in sorted(vars(args).items()):
 		print("\t", property, ": ", value)
 
-if args.debug:
-	component = 'debug'
-else:
-	component = 'main'
-
 apt_sources = [
-	AptSource('deb', args.repo, args.suite, (component,)),
-	AptSource('deb-src', args.repo, args.suite, (component,)),
+	AptSource('deb', args.repo, args.suite, ('main',)),
+	AptSource('deb-src', args.repo, args.suite, ('main',)),
 ]
 
 for line in args.extra_apt_sources:


### PR DESCRIPTION
The Steam Runtime has historically been built in two flavours,
"release" and "sym-src-debug". The sym-src-debug version is built with
the --symbols and --debug options.

The --symbols option adds detached debug symbols, which is entirely
reasonable.

The --debug option does two orthogonal things:

- It adds more packages. Historically, this was selected by filtering
  packages.txt differently; now it uses different metapackages to
  achieve the same result.
- It switches from the 'main' component in the apt repository to a
  separate 'debug' component. This contains an independent build of
  each package, built at a different time with a different version
  number. If we are unlucky, the debug builds will also have been
  built with different dependencies, or in pathological cases maybe
  even from different source code. At some point in the past they might
  have been built with different DEB_BUILD_OPTIONS like noopt, although
  this does not appear to be done any more.

Switching to a separate build is unhelpful when using the detached
debug symbols: it makes the detached debug symbols not match the
library from the normal runtime, preventing their use when analyzing
an existing core dump.

Repurpose the --debug option for only the first half of its historical
role: install the -dev packages, but use the same apt repository that
contains the production binaries.

Signed-off-by: Simon McVittie <smcv@collabora.com>