### PR TITLE
bootstrap-runtime: Offer gcc-5 and clang-3.8 if available

### DIFF
--- a/scripts/bootstrap-runtime.sh
+++ b/scripts/bootstrap-runtime.sh
@@ -174,11 +174,22 @@ heredoc
   update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
   update-alternatives --install /usr/bin/cpp cpp-bin /usr/bin/cpp-4.8 100
 
+  if [ -x /usr/bin/g++-5 ]; then
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 50
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 50
+    update-alternatives --install /usr/bin/cpp cpp-bin /usr/bin/cpp-5 50
+  fi
+
   update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-3.4 50
   update-alternatives --install /usr/bin/g++ g++ /usr/bin/clang++-3.4 50
 
   update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-3.6 50
   update-alternatives --install /usr/bin/g++ g++ /usr/bin/clang++-3.6 50
+
+  if [ -x /usr/bin/clang++-3.8 ]; then
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-3.8 50
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/clang++-3.8 50
+  fi
 
   # gcc-4.8 is the default
   update-alternatives --set gcc /usr/bin/gcc-4.8


### PR DESCRIPTION
They're in the apt repository and will likely be pulled in by future
versions of the steamrt-dev metapackage.