### PR TITLE
build-runtime: Create debug symbol symlinks with the name gdb looks for

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -948,7 +948,7 @@ def fix_debuglinks ():
 						linkdir = os.path.join(args.output, arch, "usr/lib/debug/.build-id", m.group(1))
 						if not os.access(linkdir, os.W_OK):
 							os.makedirs(linkdir)
-						link = os.path.join(linkdir,m.group(2))
+						link = os.path.join(linkdir, m.group(2) + '.debug')
 						if args.verbose:
 							print("SYMLINKING symbol file %s to %s" % (link, os.path.relpath(os.path.join(dir,file),linkdir)))
 						if os.path.lexists(link):


### PR DESCRIPTION
As documented in `info gdb "Separate Debug Files"`, gdb looks for
build-ID-based debug symbols for a library with build ID 0123456789abcdef
under the name `.build-id/01/23456789abcdef.debug`. Previously we
created `usr/lib/debug/.build-id/01/23456789abcdef`, without the
`.debug` extension.