### PR TITLE
Catch up with Steam Runtime 0.20190913.0

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -1014,23 +1014,22 @@ def install_symbols(dbgsym_by_arch, binarylist, manifest):
 # to their relative equivalent
 #
 def fix_symlinks ():
-	for arch in args.architectures:
-		for dir, subdirs, files in os.walk(os.path.join(args.output, arch)):
-			for name in files:
-				filepath=os.path.join(dir,name)
-				if os.path.islink(filepath):
-					target = os.readlink(filepath)
-					if os.path.isabs(target):
-						#
-						# compute the target of the symlink based on the 'root' of the architecture's runtime
-						#
-						target2 = os.path.join(args.output, arch, target[1:])
+	for dir, subdirs, files in os.walk(args.output):
+		for name in files:
+			filepath=os.path.join(dir,name)
+			if os.path.islink(filepath):
+				target = os.readlink(filepath)
+				if os.path.isabs(target):
+					#
+					# compute the target of the symlink based on the 'root' of the runtime
+					#
+					target2 = os.path.join(args.output, target[1:])
 
-						#
-						# Set the new relative target path
-						#
-						os.unlink(filepath)
-						os.symlink(os.path.relpath(target2,dir), filepath)
+					#
+					# Set the new relative target path
+					#
+					os.unlink(filepath)
+					os.symlink(os.path.relpath(target2,dir), filepath)
 
 
 # Creates the usr/lib/debug/.build-id/xx/xxxxxxxxx.debug symlink tree for all the debug

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -899,6 +899,16 @@ def install_deb (basename, deb, dest_dir):
 	#
 	os.chdir(top)
 	subprocess.check_call(['dpkg-deb', '-x', deb, dest_dir])
+	try:
+		shutil.rmtree(
+			os.path.join(
+				dest_dir, 'usr', 'share', 'doc',
+				'nvidia-cg-toolkit', 'examples',
+			)
+		)
+	except OSError as e:
+		if e.errno != errno.ENOENT:
+			raise
 
 
 def install_symbols(dbgsym_by_arch, binarylist, manifest):

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -1287,7 +1287,7 @@ if args.archive is not None:
 		compressor_args = ['bzip2', '-c']
 
 	if os.path.isdir(args.archive) or args.archive.endswith('/'):
-		archive_basename = name_version
+		archive_basename = name_version		# type: typing.Optional[str]
 		archive_dir = args.archive
 		archive = os.path.join(archive_dir, archive_basename + ext)
 		make_latest_symlink = (version != 'latest')
@@ -1371,6 +1371,7 @@ if args.archive is not None:
 		))
 
 	if archive_dir is not None:
+		assert archive_basename is not None
 		print("Copying manifest files to %s..." % archive_dir)
 
 		with open(

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -520,8 +520,18 @@ def ignore_metapackage_dependency(name):
 	return name in (
 		# Must be provided by host system
 		'libc6',
+		'libegl-mesa0',
+		'libegl1-mesa',
+		'libegl1-mesa-drivers',
 		'libgl1-mesa-dri',
 		'libgl1-mesa-glx',
+		'libgles1-mesa',
+		'libgles2-mesa',
+		'libglx-mesa0',
+		'mesa-opencl-icd',
+		'mesa-va-drivers',
+		'mesa-vdpau-drivers',
+		'mesa-vulkan-drivers',
 
 		# Provided by host system alongside Mesa if needed
 		'libtxc-dxtn-s2tc0',
@@ -560,8 +570,18 @@ def ignore_transitive_dependency(name):
 	return name in (
 		# Must be provided by host system
 		'libc6',
+		'libegl-mesa0',
+		'libegl1-mesa',
+		'libegl1-mesa-drivers',
 		'libgl1-mesa-dri',
 		'libgl1-mesa-glx',
+		'libgles1-mesa',
+		'libgles2-mesa',
+		'libglx-mesa0',
+		'mesa-opencl-icd',
+		'mesa-va-drivers',
+		'mesa-vdpau-drivers',
+		'mesa-vulkan-drivers',
 
 		# Assumed to be provided by host system if needed
 		'ca-certificates',

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -598,7 +598,6 @@ def ignore_transitive_dependency(name):
 		'libdrm-radeon1',
 		'libdrm-nouveau1a',
 		'libdrm2',
-		'libgdk-pixbuf2.0-common',
 		'libglapi-mesa',
 		'libllvm3.0',
 		'libopenal-data',
@@ -609,6 +608,10 @@ def ignore_transitive_dependency(name):
 		'shared-mime-info',
 		'sound-theme-freedesktop',
 		'x11-common',
+
+		# Non-essential: only contains localizations
+		'libgdk-pixbuf2.0-common',
+		'libjson-glib-1.0-common',
 
 		# Depended on by packages that are present for historical
 		# reasons

--- a/templates/run.sh
+++ b/templates/run.sh
@@ -42,7 +42,7 @@ if [ "${STEAM_RUNTIME_PREFER_HOST_LIBRARIES-}" != "0" ]; then
     host_library_paths="$STEAM_RUNTIME/pinned_libs_32:$STEAM_RUNTIME/pinned_libs_64:$host_library_paths"
 fi
 
-steam_runtime_library_paths="$host_library_paths$STEAM_RUNTIME/i386/lib/i386-linux-gnu:$STEAM_RUNTIME/i386/lib:$STEAM_RUNTIME/i386/usr/lib/i386-linux-gnu:$STEAM_RUNTIME/i386/usr/lib:$STEAM_RUNTIME/amd64/lib/x86_64-linux-gnu:$STEAM_RUNTIME/amd64/lib:$STEAM_RUNTIME/amd64/usr/lib/x86_64-linux-gnu:$STEAM_RUNTIME/amd64/usr/lib"
+steam_runtime_library_paths="$host_library_paths$STEAM_RUNTIME/lib/i386-linux-gnu:$STEAM_RUNTIME/usr/lib/i386-linux-gnu:$STEAM_RUNTIME/lib/x86_64-linux-gnu:$STEAM_RUNTIME/usr/lib/x86_64-linux-gnu:$STEAM_RUNTIME/lib:$STEAM_RUNTIME/usr/lib"
 
 if [ "$1" = "--print-steam-runtime-library-paths" ]; then
     echo "$steam_runtime_library_paths"

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -409,7 +409,7 @@ main ()
                     arch=i386
                     ;;
             esac
-            echo "$top/$arch/bin:$top/$arch/usr/bin"
+            echo "$top/$arch/bin:$top/$arch/usr/bin:$top/usr/bin"
             ;;
 
         (setup)

--- a/tests/pycodestyle.sh
+++ b/tests/pycodestyle.sh
@@ -16,8 +16,15 @@ fi
 
 echo "1..2"
 
+# E117: over-indented
+# W191: indentation contains tabs
+# E211: whitespace before ‘(‘
+# E225: missing whitespace around operator
+# E231: missing whitespace after ‘,’, ‘;’, or ‘:’
+# E501: line too long (82 > 79 characters)
+# W503: line break before binary operator
 if "${PYCODESTYLE}" \
-    --ignore=W191,E211,E225,E231,E501,W503 \
+    --ignore=E117,W191,E211,E225,E231,E501,W503 \
     build-runtime.py \
     >&2; then
     echo "ok 1 - $PYCODESTYLE reported no issues"


### PR DESCRIPTION
This PR pulls in the version of the steam-runtime tools that was used to build beta 0.20190913.0. It should also be fine to run against the state of older releases in the apt repository.

(@TTimo, you might want to push this as a fast-forward, instead of clicking Merge in the web UI, which will result in a merge commit.)

Summary of changes:

* Cope with newer `steamrt` metapackages having more diagnostic tools, which pull in more dependencies.
* Discard some NVIDIA Cg example source code, partially addressing #77 and reducing the size of the runtime.
* Combine most of the architecture-specific directories into a single merged directory hierarchy. `amd64/usr/bin` and `i386/usr/bin` remain architecture-dependent (we will use `amd64/usr/bin`, unless running on an (unsupported) 32-bit system, in which case we will use `i386/usr/bin`), but everything else can be merged. This results in some deduplication of `usr/share` files, further reducing the size of the runtime.

----

Individual commits:

* build-runtime: Skip more Mesa libraries
    
    Some diagnostic tools that I'm looking at adding to the Steam Runtime
    would pull in EGL and GLES libraries in addition to GLX and
    "desktop GL". We want all of these to be taken from the host system.
    
    While I'm here, also add the various Mesa ICDs used with GLVND-style
    loaders. We don't want to include those in the Runtime either.

* build-runtime: Ignore transitive dependencies on locale data
    
    Some diagnostic tools that I'm looking at adding might pull in
    json-glib, a JSON library for GLib-flavoured C.
    libjson-glib-1.0-common only contains non-essential locale data,
    which isn't really worth the space it would consume in the Steam
    Runtime: developer-facing messages like "No node available at the
    current position" are not going to be particularly comprehensible
    to our users, regardless of the language into which they are translated.

*  build-runtime: Fix a mypy warning

* pycodestyle: Ignore E117 'over-indented' in build-runtime.py
    
    For historical reasons, build-runtime.py is indented with hard tabs.

* build-runtime: Combine directories used by steam-runtime-tools
    
    steam-runtime-tools expects to find the ABI expectations and the
    "helper" tools that it uses in a single directory each.

* build-runtime: Delete /usr/share/doc/nvidia-cg-toolkit/examples
    
    This adds 8.8M of unnecessary files to the runtime (twice, because it
    is present for both architectures), and is one of the few things that
    collides between the amd64/ and i386/ directories, other than executables
    in usr/bin/ (which are necessarily going to be different).

* build-runtime: Combine all directories that we can
    
    steam-runtime-tools expects to find the ABI expectations and the
    "helper" tools that it uses in a single directory each, so it benefits
    from at least usr/lib/steamrt and usr/libexec/steam-runtime-tools-0
    being combined.
    
    However, recent Steam Runtime development has been careful to only
    include files that are multiarch-compatible and do not collide, so
    there isn't really any reason not to merge the whole tree, except for
    usr/bin (and in theory bin, sbin, usr/sbin) which contains executables
    for each architecture.
    
    This saves approximately 25% of the compressed size of the Steam
    Runtime (when using gzip).

* run.sh: Drop redundant directories from LD_LIBRARY_PATH
    
    Now that amd64/lib and i386/lib are the same directory, and likewise
    for amd64/usr/lib and i386/usr/lib, we can simplify the LD_LIBRARY_PATH.
    
    Move /lib and /usr/lib to the end of the search path. This is
    consistent with the search order on a multiarch Debian system, where
    all of the multiarch library directories take precedence over the
    unspecified-architecture directories.

* build-runtime: Adjust fix_symlinks() for amd64/i386 merge

* Make sure *-linux-gnu-* helpers for both architectures are on the PATH