### PR TITLE
setup_chroot.sh: Allow changing the chroot name

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -1014,23 +1014,22 @@ def install_symbols(dbgsym_by_arch, binarylist, manifest):
 # to their relative equivalent
 #
 def fix_symlinks ():
-	for arch in args.architectures:
-		for dir, subdirs, files in os.walk(os.path.join(args.output, arch)):
-			for name in files:
-				filepath=os.path.join(dir,name)
-				if os.path.islink(filepath):
-					target = os.readlink(filepath)
-					if os.path.isabs(target):
-						#
-						# compute the target of the symlink based on the 'root' of the architecture's runtime
-						#
-						target2 = os.path.join(args.output, arch, target[1:])
+	for dir, subdirs, files in os.walk(args.output):
+		for name in files:
+			filepath=os.path.join(dir,name)
+			if os.path.islink(filepath):
+				target = os.readlink(filepath)
+				if os.path.isabs(target):
+					#
+					# compute the target of the symlink based on the 'root' of the runtime
+					#
+					target2 = os.path.join(args.output, target[1:])
 
-						#
-						# Set the new relative target path
-						#
-						os.unlink(filepath)
-						os.symlink(os.path.relpath(target2,dir), filepath)
+					#
+					# Set the new relative target path
+					#
+					os.unlink(filepath)
+					os.symlink(os.path.relpath(target2,dir), filepath)
 
 
 # Creates the usr/lib/debug/.build-id/xx/xxxxxxxxx.debug symlink tree for all the debug

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -899,6 +899,16 @@ def install_deb (basename, deb, dest_dir):
 	#
 	os.chdir(top)
 	subprocess.check_call(['dpkg-deb', '-x', deb, dest_dir])
+	try:
+		shutil.rmtree(
+			os.path.join(
+				dest_dir, 'usr', 'share', 'doc',
+				'nvidia-cg-toolkit', 'examples',
+			)
+		)
+	except OSError as e:
+		if e.errno != errno.ENOENT:
+			raise
 
 
 def install_symbols(dbgsym_by_arch, binarylist, manifest):

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -1287,7 +1287,7 @@ if args.archive is not None:
 		compressor_args = ['bzip2', '-c']
 
 	if os.path.isdir(args.archive) or args.archive.endswith('/'):
-		archive_basename = name_version
+		archive_basename = name_version		# type: typing.Optional[str]
 		archive_dir = args.archive
 		archive = os.path.join(archive_dir, archive_basename + ext)
 		make_latest_symlink = (version != 'latest')
@@ -1371,6 +1371,7 @@ if args.archive is not None:
 		))
 
 	if archive_dir is not None:
+		assert archive_basename is not None
 		print("Copying manifest files to %s..." % archive_dir)
 
 		with open(

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -520,8 +520,18 @@ def ignore_metapackage_dependency(name):
 	return name in (
 		# Must be provided by host system
 		'libc6',
+		'libegl-mesa0',
+		'libegl1-mesa',
+		'libegl1-mesa-drivers',
 		'libgl1-mesa-dri',
 		'libgl1-mesa-glx',
+		'libgles1-mesa',
+		'libgles2-mesa',
+		'libglx-mesa0',
+		'mesa-opencl-icd',
+		'mesa-va-drivers',
+		'mesa-vdpau-drivers',
+		'mesa-vulkan-drivers',
 
 		# Provided by host system alongside Mesa if needed
 		'libtxc-dxtn-s2tc0',
@@ -560,8 +570,18 @@ def ignore_transitive_dependency(name):
 	return name in (
 		# Must be provided by host system
 		'libc6',
+		'libegl-mesa0',
+		'libegl1-mesa',
+		'libegl1-mesa-drivers',
 		'libgl1-mesa-dri',
 		'libgl1-mesa-glx',
+		'libgles1-mesa',
+		'libgles2-mesa',
+		'libglx-mesa0',
+		'mesa-opencl-icd',
+		'mesa-va-drivers',
+		'mesa-vdpau-drivers',
+		'mesa-vulkan-drivers',
 
 		# Assumed to be provided by host system if needed
 		'ca-certificates',

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -598,7 +598,6 @@ def ignore_transitive_dependency(name):
 		'libdrm-radeon1',
 		'libdrm-nouveau1a',
 		'libdrm2',
-		'libgdk-pixbuf2.0-common',
 		'libglapi-mesa',
 		'libllvm3.0',
 		'libopenal-data',
@@ -609,6 +608,10 @@ def ignore_transitive_dependency(name):
 		'shared-mime-info',
 		'sound-theme-freedesktop',
 		'x11-common',
+
+		# Non-essential: only contains localizations
+		'libgdk-pixbuf2.0-common',
+		'libjson-glib-1.0-common',
 
 		# Depended on by packages that are present for historical
 		# reasons

--- a/templates/run.sh
+++ b/templates/run.sh
@@ -42,7 +42,7 @@ if [ "${STEAM_RUNTIME_PREFER_HOST_LIBRARIES-}" != "0" ]; then
     host_library_paths="$STEAM_RUNTIME/pinned_libs_32:$STEAM_RUNTIME/pinned_libs_64:$host_library_paths"
 fi
 
-steam_runtime_library_paths="$host_library_paths$STEAM_RUNTIME/i386/lib/i386-linux-gnu:$STEAM_RUNTIME/i386/lib:$STEAM_RUNTIME/i386/usr/lib/i386-linux-gnu:$STEAM_RUNTIME/i386/usr/lib:$STEAM_RUNTIME/amd64/lib/x86_64-linux-gnu:$STEAM_RUNTIME/amd64/lib:$STEAM_RUNTIME/amd64/usr/lib/x86_64-linux-gnu:$STEAM_RUNTIME/amd64/usr/lib"
+steam_runtime_library_paths="$host_library_paths$STEAM_RUNTIME/lib/i386-linux-gnu:$STEAM_RUNTIME/usr/lib/i386-linux-gnu:$STEAM_RUNTIME/lib/x86_64-linux-gnu:$STEAM_RUNTIME/usr/lib/x86_64-linux-gnu:$STEAM_RUNTIME/lib:$STEAM_RUNTIME/usr/lib"
 
 if [ "$1" = "--print-steam-runtime-library-paths" ]; then
     echo "$steam_runtime_library_paths"

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -409,7 +409,7 @@ main ()
                     arch=i386
                     ;;
             esac
-            echo "$top/$arch/bin:$top/$arch/usr/bin"
+            echo "$top/$arch/bin:$top/$arch/usr/bin:$top/usr/bin"
             ;;
 
         (setup)

--- a/tests/pycodestyle.sh
+++ b/tests/pycodestyle.sh
@@ -16,8 +16,15 @@ fi
 
 echo "1..2"
 
+# E117: over-indented
+# W191: indentation contains tabs
+# E211: whitespace before ‘(‘
+# E225: missing whitespace around operator
+# E231: missing whitespace after ‘,’, ‘;’, or ‘:’
+# E501: line too long (82 > 79 characters)
+# W503: line break before binary operator
 if "${PYCODESTYLE}" \
-    --ignore=W191,E211,E225,E231,E501,W503 \
+    --ignore=E117,W191,E211,E225,E231,E501,W503 \
     build-runtime.py \
     >&2; then
     echo "ok 1 - $PYCODESTYLE reported no issues"


### PR DESCRIPTION
(This is based on #181: please review that first.)

Being able to change the name makes it easier to experiment with the `--tarball` option, by using something like

    ./setup_chroot.sh --name steamrt_scout_sysroot_amd64 --tarball ~/Downloads/com.valvesoftware.SteamRuntime.Sdk-amd64\,i386-scout-sysroot.tar.gz --amd64

to get parallel `steamrt_scout_amd64` and `steamrt_scout_sysroot_amd64` chroots.