### PR TITLE
Ignore packages of the wrong architecture in Packages files

### DIFF
--- a/build-runtime.py
+++ b/build-runtime.py
@@ -520,6 +520,13 @@ def list_binaries(
 				for stanza in deb822.Packages.iter_paragraphs(
 					url_file_handle
 				):
+					if stanza['Architecture'] not in ('all', arch):
+						print('Found %s package %s in %s Packages file' % (
+							stanza['Architecture'],
+							stanza['Package'],
+							arch,
+						))
+						continue
 					p = stanza['Package']
 					binary = Binary(apt_source, stanza)
 					by_name.setdefault(p, []).append(

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -308,6 +308,8 @@ def download_file(file_url, file_path):
 		pass
 
 	try:
+		if args.verbose:
+			print("Downloading %s to %s" % (file_url, file_path))
 		urlretrieve(file_url, file_path)
 	except Exception:
 		sys.stderr.write('Error downloading %s:\n' % file_url)
@@ -916,6 +918,8 @@ def install_binaries(binaries_by_arch, binarylists, manifest):
 
 
 def install_deb (basename, deb, dest_dir):
+	if args.verbose:
+		print('Unpacking %s into %s' % (deb, dest_dir))
 	check_path_traversal(basename)
 	installtag_dir=os.path.join(dest_dir, "installed")
 	if not os.access(installtag_dir, os.W_OK):

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -301,6 +301,8 @@ def parse_args():
 def download_file(file_url, file_path):
 	try:
 		if os.path.getsize(file_path) > 0:
+			if args.verbose:
+				print("Skipping download of existing file: %s" % file_path)
 			return False
 	except OSError:
 		pass
@@ -373,10 +375,7 @@ def install_sources(apt_sources, sourcelist):
 					file['name']
 				)
 				if not download_file(file_url, file_path):
-					if args.verbose:
-						print("Skipping download of existing deb source file(s): %s" % file_path)
-					else:
-						skipped += 1
+					skipped += 1
 
 			for file in sp.stanza['files']:
 				if args.strict:
@@ -807,10 +806,7 @@ def install_binaries(binaries_by_arch, binarylists, manifest):
 					os.path.basename(newest.stanza['Filename']),
 				)
 				if not download_file(file_url, dest_deb):
-					if args.verbose:
-						print("Skipping download of existing deb: %s" % dest_deb)
-					else:
-						skipped += 1
+					skipped += 1
 				install_deb(
 					os.path.splitext(
 						os.path.basename(
@@ -1018,10 +1014,7 @@ def install_symbols(dbgsym_by_arch, binarylist, manifest):
 						dbgsym.stanza['Filename'])
 				)
 				if not download_file(file_url, dest_deb):
-					if args.verbose:
-						print("Skipping download of existing symbol deb: %s", dest_deb)
-					else:
-						skipped += 1
+					skipped += 1
 				install_deb(
 					os.path.splitext(
 						os.path.basename(

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -182,11 +182,6 @@ pin_newer_runtime_libs ()
         fi
 
         case "$soname" in
-            (libSDL2-2.0.so.0)
-                # We know the Steam Runtime has an up-to-date SDL2.
-                runtime_version_newer="forced"
-                ;;
-
             (libcurl.so.4)
                 # libcurl in the Steam Runtime is internally identified
                 # as libcurl.so.4, but with a symlink at libcurl.so.3


### PR DESCRIPTION
When adding extra apt sources with `--extra-apt-source`, if the amd64 and i386 `Packages` metadata files for the extra apt source both contain both amd64 and i386 packages, `build-runtime.py` gets confused and installs the amd64 package twice (in fact it will install whichever package appears first, but in the situation where I encountered this, the amd64 package came first in both Packages files). This branch fixes that failure mode.

----

* build-runtime: Centralize logging of skipped downloads

* Make verbose mode more verbose
    
    When something goes wrong with downloading and unpacking archives,
    this makes it clearer what is going on.

* Ignore i386 packages in the amd64 Packages file and vice versa
    
    The apt repositories generated for personal branches in the Open Build
    Service have separate i386 and amd64 Packages files, but each lists
    packages for both architectures. When installing libraries for i386,
    we need to skip the amd64 stanzas and vice versa.
    
    As a special case, architecture-independent data files (Architecture: all)
    continue to be considered to be a valid part of every architecture.