### PR TITLE
Fix misleading warning message

### DIFF
--- a/setup_chroot.sh
+++ b/setup_chroot.sh
@@ -64,7 +64,7 @@ prebuild_chroot()
 			name="${CHROOT_PREFIX}${var/--/}"
 		fi
 
-		dirname="${CHROOT_DIR}/${CHROOT_NAME}"
+		dirname="${CHROOT_DIR}/${name}"
 		if [ -d "${dirname}" ]; then
 			tput setaf 3
 			STEAM_RUNTIME_SPEW_WARNING=1


### PR DESCRIPTION
If `--name` wasn't explicitly used, the warning would say

    About to remove /var/chroots/ and re-install...

which sounds more drastic than what will actually happen.