### PR TITLE
Document how to use detached debug symbols with the Steam Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,34 @@ is not guaranteed to match the official sysroot tarballs, and whether
 it succeeds is heavily dependent on the operating system on which you
 are running the tool, so this approach is no longer recommended.
 
+### Using a debugger in the build environment
+
+To get the detached debug symbols that are required for `gdb` and
+similar tools, you can download the matching
+`com.valvesoftware.SteamRuntime.Sdk-amd64,i386-scout-debug.tar.gz`,
+unpack it (preserving directory structure), and use its `files/`
+directory as the schroot or container's `/usr/lib/debug`.
+
+For example, with Docker, you might unpack the tarball in
+`/tmp/scout-dbgsym-0.20190711.3` and use something like:
+
+    sudo docker run \
+    --rm \
+    --init \
+    -v /home:/home \
+    -v /tmp/scout-dbgsym-0.20190711.3/files:/usr/lib/debug \
+    -e HOME=/home/user \
+    -u $(id -u):$(id -g) \
+    -h $(hostname) \
+    -v /tmp:/tmp \
+    -it \
+    steamrt_scout_amd64:latest \
+    /dev/init -sg -- /bin/bash
+
+or with schroot, you might create
+`/var/chroots/steamrt_scout_amd64/usr/lib/debug/` and move the contents
+of `files/` into it.
+
 Default Tools
 -------------
 
@@ -225,5 +253,128 @@ Switching default compilers can be done by entering the chroot environment:
     (steamrt_scout_i386):~$ update-alternatives --set gcc /usr/bin/clang-3.6
     (steamrt_scout_i386):~$ update-alternatives --set g++ /usr/bin/clang++-3.6
     (steamrt_scout_i386):~$ update-alternatives --set cpp-bin /usr/bin/cpp-4.8
-    
 
+Using detached debug symbols
+----------------------------
+
+If your game runs in the `LD_LIBRARY_PATH`-based Steam Runtime
+environment, it is likely to be loading a mixture of libraries from the
+host system and libraries from the Steam Runtime. In this situation,
+debugging with tools like `gdb` benefits from having
+[debug symbols][].
+
+Like typical Linux operating system library stacks, the Steam Runtime
+libraries do not contain debug symbols, to keep their size small; however,
+they were compiled with debug symbols included, so we can make their
+corresponding [detached debug symbols][] available for download.
+
+The steps to attach a debugger to a game apply can in fact apply equally
+to the Steam client itself.
+
+[debug symbols]: https://en.wikipedia.org/wiki/Debug_symbol
+[detached debug symbols]: https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
+
+### Example scenario
+
+Suppose you are using a SteamOS 2 'brewmaster' host system, and you are
+having difficulty with the PulseAudio libraries, similar to
+[steam-for-linux#4753][].
+
+* Use a SteamOS 2 'brewmaster' host system
+* Ensure that your Steam client is up to date
+* Do not have `libpulse0:i386` or `libopenal1:i386` installed, so that
+    the 32-bit `libpulse.so.0` and `libopenal.so.1` from the Steam Runtime
+    will be used
+* Run the Steam client in "desktop mode", from a terminal
+* Put the Steam client in Big Picture mode, which makes it initialize
+    PulseAudio
+* Run a 32-bit game like [Floating Point][]
+* Alt-tab to a terminal
+* Locate the main Steam process with `pgrep steam | xargs ps`,
+    or locate the main Floating Point process with `pgrep Float | xargs ps`.
+    Let's say the process you are interested in is process 12345.
+* Run a command like
+    `gdb ~/.steam/root/ubuntu12_32/steam 12345` (for the Steam client)
+    or `gdb ~/.steam/steam/steamapps/common/"Floating Point"/"Floating Point.x86" 12345`
+    (for the game).
+* In gdb: `set pagination off`
+* In gdb: `thread apply all bt` to see a backtrace of each thread.
+* At the time of writing, the Steam client has two threads that are
+    calling `pa_mainloop_run()`, while Floating Point has one such thread.
+    Because you don't have debug symbols for `libpulse.so.0`, these
+    backtraces are quite vague, with no information about the source
+    code file/line or about the function arguments.
+* Exit from gdb so that the Steam client or the game can continue to run.
+
+[Floating Point]: https://store.steampowered.com/app/302380
+[steam-for-linux#4753]: https://github.com/ValveSoftware/steam-for-linux/issues/4753#issuecomment-280920124
+
+### Getting the debug symbols for the host system
+
+This is the same as it would be without Steam. For a Debian, Ubuntu or
+SteamOS host, `apt install libc6-dbg:i386` is a good start. For
+non-Debian-derived OSs, use whatever is the OS's usual mechanism to get
+detached debug symbols.
+
+### Getting the debug symbols for the Steam Runtime
+
+Look in `~/.steam/root/ubuntu12_32/steam-runtime/version.txt` to see
+which Steam Runtime you have. At the time of writing, the public stable
+release is version 0.20190711.3.
+
+Look in <http://repo.steampowered.com/steamrt-images-scout/snapshots/>
+for a corresponding version of the Steam Runtime container builds.
+
+Download
+`com.valvesoftware.SteamRuntime.Sdk-amd64,i386-scout-debug.tar.gz` from
+the matching build. Create a directory, for example
+`/tmp/scout-dbgsym-0.20190711.3`, and untar the debug symbols tarball
+into that directory.
+
+The `/tmp/scout-dbgsym-0.20190711.3/files` directory is actually the
+`/usr/lib/debug` from the SDK container, and has most of the debug
+symbols that you will need.
+
+If your Steam Runtime is older than 0.20190716.1, you will need to use
+the `scripts/dbgsym-use-build-id` script, with a command like
+
+    /path/to/dbgsym-use-build-id /tmp/scout-dbgsym-0.20190711.3/files
+
+to create build-ID-based links to any detached debug symbols that had
+legacy path-based names. This step will become unnecessary with the
+0.20190716.1 or newer Steam Runtime, which ran that script while
+they were prepared.
+
+### Re-running gdb
+
+Run gdb the same as you did before, but this time use the `-iex` option
+to tell it to set the new debug symbols directory before loading the
+executable, for example:
+
+    gdb -iex \
+    'set debug-file-directory /tmp/scout-debug-0.20190711.3/files:/usr/lib/debug' \
+    ~/.steam/root/ubuntu12_32/steam 12345
+
+You will get some warnings about CRC mismatches, because gdb can now
+see two versions of the debug symbols for some libraries. Those warnings
+can safely be ignored: gdb does the right thing.
+
+### Example scenario revisited
+
+* Do the setup above
+* Run a command like
+    `gdb ~/.steam/root/ubuntu12_32/steam 12345` (for the Steam client)
+    or `gdb ~/.steam/steam/steamapps/common/"Floating Point"/"Floating Point.x86" 12345`
+    (for the game).
+* In gdb: `set pagination off`
+* In gdb: `thread apply all bt` to see a backtrace of each thread.
+* At the time of writing, the Steam client has two threads that are
+    calling `pa_mainloop_run()`, while Floating Point has one such thread.
+    Now that you have debug symbols for `libpulse.so.0`, these backtraces
+    are more specific, with the source file, line number and function
+    arguments for calls into `libpulse.so.0`, and details of functions
+    that are internal to `libpulse.so.0`.
+* Similarly, for `start_thread()` in `libc.so.6` (which came from the host
+    system), you should see file and line information from `libc6-dbg:i386`.
+* If you use `info locals` or `thread apply all bt full`, you'll also see
+    that you can even get information about local variables.

--- a/scripts/dbgsym-use-build-id
+++ b/scripts/dbgsym-use-build-id
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+# Copyright 2013-2019 Valve Corporation
+# Copyright 2019 Collabora Ltd.
+#
+# SPDX-License-Identifier: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import argparse
+import logging
+import os
+import re
+import subprocess
+import sys
+
+
+"""
+Provide build-ID-based hard links to legacy path-based debugging symbols.
+
+Based on build-runtime.py in steam-runtime.
+"""
+
+
+logger = logging.getLogger('flatdeb.dbgsym-use-build-id')
+
+
+def main():
+    # type: (...) -> None
+
+    parser = argparse.ArgumentParser(
+        description=(
+            'Provide build-ID-based hard links for legacy debug symbols'
+        ),
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        default=False,
+    )
+    parser.add_argument('--debug-dir', default='/usr/lib/debug')
+
+    args = parser.parse_args()
+
+    for dirname, subdirs, files in os.walk(args.debug_dir):
+        # Skip build-ID directory: it is already in the form we wanted
+        if '.build-id' in subdirs:
+            subdirs.remove('.build-id')
+
+        for f in files:
+            if f.endswith('.txt'):
+                continue
+
+            # Scrape the output of readelf to find the build-ID for this
+            # binary
+            path = os.path.join(dirname, f)
+
+            with subprocess.Popen([
+                os.environ.get('READELF', 'readelf'), '-n', path,
+            ], stdout=subprocess.PIPE, universal_newlines=True) as p:
+                for line in p.stdout:
+                    m = re.search(
+                        r'Build ID: ([a-fA-F0-9]{2})([a-fA-F0-9]+)',
+                        line,
+                        re.ASCII,
+                    )
+                    if m is None:
+                        continue
+
+                    # ensure no path traversal
+                    assert '.' not in m.group(1)
+                    assert '.' not in m.group(2)
+                    linkdir = os.path.join(
+                        args.debug_dir, '.build-id', m.group(1),
+                    )
+                    link = os.path.join(linkdir, m.group(2) + '.debug')
+
+                    if args.dry_run:
+                        logger.info('Would hard-link %s as %s', path, link)
+                    else:
+                        logger.info('Hard-linking %s as %s', path, link)
+
+                        if not os.access(linkdir, os.W_OK):
+                            os.makedirs(linkdir)
+
+                        if os.path.lexists(link):
+                            os.unlink(link)
+
+                        os.link(os.path.join(dirname, f), link)
+
+                    break
+                else:
+                    logger.warning(
+                        'Unable to create build-ID-based hard link to %s',
+                        path,
+                    )
+
+
+if __name__ == '__main__':
+    if sys.stderr.isatty():
+        try:
+            import colorlog
+        except ImportError:
+            pass
+        else:
+            formatter = colorlog.ColoredFormatter(
+                '%(log_color)s%(levelname)s:%(name)s:%(reset)s %(message)s')
+            handler = logging.StreamHandler()
+            handler.setFormatter(formatter)
+            logging.getLogger().addHandler(handler)
+    else:
+        logging.basicConfig()
+
+    logging.getLogger().setLevel(logging.DEBUG)
+
+    try:
+        main()
+    except KeyboardInterrupt:
+        raise SystemExit(130)


### PR DESCRIPTION
The dbgsym-use-build-id script was taken from
<https://gitlab.collabora.com/smcv/flatdeb>. It is only necessary as long
as the production version of the Steam Runtime was built with a version
of flatdeb that did not have that script.