### PR TITLE
Removed unnecessary double quote SC2027

### DIFF
--- a/setup_chroot.sh
+++ b/setup_chroot.sh
@@ -87,7 +87,7 @@ copy_apt_settings ()
 	local sysroot="$1"
 
 	if [ "$1/" -ef / ]; then
-		echo "Internal error: sysroot "$1" is the same file as the real root" >&2
+		echo "Internal error: sysroot $1 is the same file as the real root" >&2
 		exit 1
 	fi
 


### PR DESCRIPTION
https://github.com/koalaman/shellcheck/wiki/SC2027

In this case, removing the double quotes I think makes more sense as you probably want to expand the argument.