### PR TITLE
Update documentation of known issues, etc.

### DIFF
--- a/doc/possible-designs.md
+++ b/doc/possible-designs.md
@@ -628,11 +628,8 @@ Games run in a container via the pressure-vessel tool:
       - host system, unrestricted
       - a private directory like ~/.var/app/com.steampowered.App440 per game
 
-"Steam Runtime 2 Platform" refers to an as-yet hypothetical Steam
-Runtime v2. For example, if we based it on an existing Linux
-distribution like Debian 10, or an existing Flatpak runtime like
-org.freedesktop.Platform//18.08, then any game that currently works in
-that environment would work here too.
+The diagram and text above uses Steam Runtime v2 'soldier' for brevity,
+but this could equally well be done with a future runtime.
 
 Entirely solves:
 
@@ -676,8 +673,6 @@ Does not solve:
 
 ## Flatpak + pressure-vessel in parallel
 
-(This is theoretical, and has not been deployed in practice.)
-
     |----------------------------
     |                    Host system
     |    flatpak run
@@ -691,7 +686,7 @@ Does not solve:
     |  |      .    |    s-rt scout |
     |  |      .    |               |
     |  |      .    \- steam binary |
-    |  |      .         \======IPC===> A portal service
+    |  |      .         \======IPC===> flatpak-portal service
     |  |---------------------------|     |
     |                                 |--\-bwrap--------------------|
     |                                 |     |             A runtime |
@@ -769,17 +764,17 @@ Mostly solves:
 Only partially solves:
 
   * Host system doesn't need uncommon packages installed
-      - This will need sufficiently capable versions of
-        Flatpak, bubblewrap and/or a portal service, unless the Steam
-        client is given the necessary permissions to execute arbitrary
-        code on the host system in order to start the game containers
+      - Flatpak 1.11.1, which is not yet a stable release, is required
 
 ### Pure Steam Runtime container for game
+
+This is implemented in pressure-vessel >= 0.20210430.0 when used with
+Flatpak 1.11.1.
 
     |----------------------------
     |                    Host system
     |
-    |  A portal service <===== IPC from Steam client
+    |  flatpak-portal service <===== IPC from Steam client
     |       |
     |  |----\-pressure-vessel-wrap, bwrap-----
     |  |       |      SteamLinuxRuntime/scout or Steam Runtime 2
@@ -888,14 +883,10 @@ Does not solve:
 
 ### Flatpak runtime container with `LD_LIBRARY_PATH` runtime inside
 
-This assumes that Flatpak can be enhanced to allow the Steam client
-to launch a parallel container with the same Flatpak runtime, and
-the same or stricter sandboxing parameters.
-
     |----------------------------
     |                    Host system
     |
-    |  A portal service <===== IPC from Steam client
+    |  flatpak-portal service <===== IPC from Steam client
     |       |
     |  |----\-Flatpak/bwrap--------------------
     |  |       |      org.freedesktop.Platform//20.08

--- a/doc/possible-designs.md
+++ b/doc/possible-designs.md
@@ -190,7 +190,7 @@ Does not solve:
     |    flatpak run
     |     |
     |  |--\-bwrap-------------------
-    |  |    |            org.freedesktop.Platform//18.08
+    |  |    |            org.freedesktop.Platform//20.08
     |  |    |
     |  |    \-steam.sh
     |  |         |
@@ -683,7 +683,7 @@ Does not solve:
     |    flatpak run
     |     |
     |  |--\-bwrap------------------|
-    |  |    |        o.fd.P//18.08 |
+    |  |    |        o.fd.P//20.08 |
     |  |    |                      |
     |  |    \-steam.sh             |
     |  |         |                 |
@@ -898,7 +898,7 @@ the same or stricter sandboxing parameters.
     |  A portal service <===== IPC from Steam client
     |       |
     |  |----\-Flatpak/bwrap--------------------
-    |  |       |      org.freedesktop.Platform//18.08
+    |  |       |      org.freedesktop.Platform//20.08
     |  |       |
     |  |   |- -\-run.sh - - - - - - - - - - - -
     |  |   .      |   Steam Runtime 1 or 2

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -185,25 +185,6 @@ maybe also
 [#340](https://github.com/ValveSoftware/steam-runtime/issues/340),
 [#341](https://github.com/ValveSoftware/steam-runtime/issues/341))
 
-Vulkan layers and driver/device selection
------------------------------------------
-
-Getting Vulkan layers from the host system to work in the container
-is complicated, and is still being worked on. In recent versions of
-pressure-vessel, *most* Vulkan layers should work, with some exceptions.
-
-This can affect the selection of driver/GPU in multi-GPU systems
-(see [Multiple-GPU systems](#issue312)).
-
-This can also affect system-wide Vulkan layers like MangoHUD and vkBasalt.
-([#295](https://github.com/ValveSoftware/steam-runtime/issues/295))
-
-Some layers will only work inside the container for 32-bit games *or*
-for 64-bit games, and not both on the same system.
-This is believed to be fixed in version 0.20210217.0 of both scout and soldier.
-However, in some cases this fix exposes other problems with Vulkan
-layers, such as [MangoHUD with Mesa 20.3.4 and 21.0.0.rc5](#issue363).
-
 /usr/local
 ----------
 

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -8,17 +8,40 @@ Here are some that are likely to affect multiple users:
 Flatpak
 -------
 
-SteamLinuxRuntime cannot be used from inside the unofficial Flatpak
-version of Steam. We are trying to make this work, but it is going
-to need changes to both pressure-vessel and Flatpak.
-Workaround: Either don't use the Flatpak version of Steam, or if you
-do, don't enable SteamLinuxRuntime or the official builds of
-Proton 5.13 (or later).
+Using the Steam container runtimes from inside a Flatpak sandbox requires
+features that are not yet available in stable Flatpak releases. To use
+the container runtimes, you will need:
 
-There is an unsupported community build of Proton 5.13 available that
-*does* work in a Flatpak environment.
+* An operating system where unprivileged users can create user
+    namespaces (non-setuid bubblewrap)
 
-([#294](https://github.com/ValveSoftware/steam-runtime/issues/294))
+    * Debian >= 11, but not Debian 10 or older
+    * RHEL/CentOS >= 8, but not RHEL/CentOS 7 or older
+    * Arch Linux with the default `linux` kernel,
+        but not `linux-hardened` and `bubblewrap-suid`
+    * Most other recent distributions, e.g. Ubuntu
+
+* Flatpak 1.11.1 or later. This is a development version, so use it at
+    your own risk.
+
+    * Ubuntu users can get this from
+        [the PPA](https://launchpad.net/~alexlarsson/+archive/ubuntu/flatpak)
+    * Debian users can get this from
+        [experimental](https://packages.debian.org/source/experimental/flatpak)
+
+* A fully up-to-date version of the Steam Flatpak app, with the
+   `per-app-dev-shm` feature listed in its permissions
+
+* A fully up-to-date version of `SteamLinuxRuntime` or
+    `SteamLinuxRuntime_soldier`, with `pressure-vessel 0.20210430.0` or
+    later listed in its `VERSIONS.txt` file
+
+As a workaround, users of older versions of Flatpak can try using
+[a community build of Proton](https://github.com/flathub/com.valvesoftware.Steam.CompatibilityTool.Proton)
+which uses the freedesktop.org runtime instead of Steam Runtime 2.
+
+([#294](https://github.com/ValveSoftware/steam-runtime/issues/294),
+[com.valvesoftware.Steam#642](https://github.com/flathub/com.valvesoftware.Steam/issues/642))
 
 Non-FHS operating systems
 -------------------------

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -94,16 +94,13 @@ on startup. The exact conditions to trigger this are complicated and not
 well-understood, but it is known to happen on many systems when Proton/DXVK
 games load the MangoHUD Vulkan layer in the Steam Linux Runtime container.
 
-Mesa version 21.0.0 contains a change that avoids this problem.
-Version 20.3.5 is expected to have the same change included, and some
-Linux distributions such as Arch Linux have backported the necessary
-patch into their packages for older Mesa releases.
+Mesa versions 21.0.0 and 20.3.5 contain a change that avoids this problem.
 
 It is not clear which component is at fault here: it might be a bug in
 Vulkan-Loader, MangoHUD, Mesa, pressure-vessel or something else. We're
 continuing to investigate.
 
-Workaround: upgrade Mesa to version 21.0.0 or later, or disable MangoHUD
+Workaround: upgrade Mesa to version 20.3.5 or later, or disable MangoHUD
 with environment variable `DISABLE_MANGOHUD=1`.
 
 ([#363](https://github.com/ValveSoftware/steam-runtime/issues/363),


### PR DESCRIPTION
* doc: Update version of o.fd.Platform in diagrams

* doc: Update "possible designs" document for current status
    
    Some of these designs have now been implemented.

* doc: Document recent Flatpak development
    
    With Flatpak 1.11.1, it is possible to run Proton games in a subsandbox.

* doc: Update for Mesa 20.3.5
    
    Mesa 20.3.5 was released and does contain the same change as 21.0.0.

* doc: Stop documenting Vulkan layers as a known issue
    
    We now share most, if not all, Vulkan layers with the container.