### PR TITLE
Update known issues, workarounds and bug reporting instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -11,13 +11,15 @@ about: Issues with the Steam runtime
 * Link to your full system information (Help -> System Information) in a [Gist](https://gist.github.com/): 
   <!-- Please wait for the extended system infomation to be collected by Steam -->
 * Have you checked for system updates?: [Yes/No]
-* Are you using the Steam Linux Runtime compatibility tool?: [Yes/No]
+* What compatibility tool are you using?: [None / Steam Linux Runtime / Proton 5.13+ / older Proton]
+* If you are using Steam Linux Runtime for native Linux games: What versions are listed in `SteamLinuxRuntime/VERSIONS.txt`?
+* If you are using Proton 5.13 or newer: What versions are listed in `SteamLinuxRuntime_soldier/VERSIONS.txt`?
 
 #### Please describe your issue in as much detail as possible:
 <!-- Describe what you _expected_ should happen and what _did_ happen. Please link any large code pastes as a [Github Gist](https://gist.github.com/) -->
 
 <!--
-If you are using the Steam Linux Runtime compatibility tool, please
+If you are using Proton or the Steam Linux Runtime compatibility tool, please
 provide the information requested here:
 https://github.com/ValveSoftware/steam-runtime/blob/master/doc/reporting-steamlinuxruntime-bugs.md
 -->

--- a/doc/reporting-steamlinuxruntime-bugs.md
+++ b/doc/reporting-steamlinuxruntime-bugs.md
@@ -66,6 +66,8 @@ log. Since version 0.20210105.0, the easiest way to get this is:
     `~/.local/share/Steam/steamapps/common/SteamLinuxRuntime`
     for scout
 
+* Version numbers for some important runtime components are in `VERSIONS.txt`
+
 * The log file is in the `var/` directory and named `slr-app*-*.log`
     for Steam games, or `slr-non-steam-game-*.log` if we cannot identify
     a Steam app ID for the game.

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -36,12 +36,22 @@ the container runtimes, you will need:
     `SteamLinuxRuntime_soldier`, with `pressure-vessel 0.20210430.0` or
     later listed in its `VERSIONS.txt` file
 
+Additionally, a known bug
+[flatpak#4286](https://github.com/flatpak/flatpak/issues/4286) can result
+in games failing to launch (it's intermittent). Re-launching the same
+game will usually succeed. This has been fixed in Flatpak git master,
+and the fix should be in 1.11.2 (not yet released).
+
 As a workaround, users of older versions of Flatpak can try using
 [a community build of Proton](https://github.com/flathub/com.valvesoftware.Steam.CompatibilityTool.Proton)
 which uses the freedesktop.org runtime instead of Steam Runtime 2.
 
 ([#294](https://github.com/ValveSoftware/steam-runtime/issues/294),
-[com.valvesoftware.Steam#642](https://github.com/flathub/com.valvesoftware.Steam/issues/642))
+[Proton#4268](https://github.com/ValveSoftware/Proton/issues/4268),
+[Proton#4283](https://github.com/ValveSoftware/Proton/issues/4283),
+[com.valvesoftware.Steam#642](https://github.com/flathub/com.valvesoftware.Steam/issues/642),
+[flatpak#3797](https://github.com/flatpak/flatpak/issues/3797),
+[flatpak#4286](https://github.com/flatpak/flatpak/issues/4286))
 
 Non-FHS operating systems
 -------------------------

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -75,7 +75,8 @@ Guix probably does not work for the same reasons as NixOS.
 Other non-FHS distributions might also not work.
 
 Workaround: don't enable SteamLinuxRuntime or Proton 5.13 (or newer)
-on OSs with unusual directory layouts.
+on OSs with unusual directory layouts, or use the unofficial Flatpak app
+(requires Flatpak 1.11.1).
 
 kernel.unprivileged\_userns\_clone
 ----------------------------------

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -92,6 +92,10 @@ kernel, either the `bubblewrap-suid` package must be installed, or the
 If any other distributions use the `kernel.unprivileged_userns_clone`
 patch, they will have similar requirements.
 
+Note that if you are running Steam under Flatpak, a setuid version of
+`/usr/bin/bwrap` will not work: the `kernel.unprivileged_userns_clone`
+sysctl parameter must be set to 1 instead.
+
 ([#342](https://github.com/ValveSoftware/steam-runtime/issues/342),
 [#297](https://github.com/ValveSoftware/steam-runtime/issues/297))
 

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -322,26 +322,39 @@ Game Maker games such as Undertale and Danger Gazers don't start
 in the `scout` runtime,
 because they assume that newer Debian/Ubuntu libraries are available.
 
-Workaround: don't use SteamLinuxRuntime for those games yet.
+Workaround: don't use SteamLinuxRuntime for those games yet, or try
+using the `scout_layered_slim` branch (but see below).
 
 ([#216](https://github.com/ValveSoftware/steam-runtime/issues/216),
-[#235](https://github.com/ValveSoftware/steam-runtime/issues/235))
+[#235](https://github.com/ValveSoftware/steam-runtime/issues/235),
+[#410](https://github.com/ValveSoftware/steam-runtime/issues/410))
 
 Haxe games such as Evoland Legendary Edition don't start in the
 `scout` runtime,
 because they assume that newer Debian/Ubuntu libraries are available.
 
-Workaround: don't use SteamLinuxRuntime for those games yet.
+Workaround: don't use SteamLinuxRuntime for those games yet, or try
+using the `scout_layered_slim` branch (but see below).
 
 ([#224](https://github.com/ValveSoftware/steam-runtime/issues/224))
 
 Feral Interactive ports such as Shadow of the Tomb Raider and Dirt 4
 crash when launched in a 'scout' container.
 
-Workaround: don't use SteamLinuxRuntime for those games yet.
+Workaround: don't use SteamLinuxRuntime for those games yet, or try
+using the `scout_layered_slim` branch (but see below).
 
 ([#202](https://github.com/ValveSoftware/steam-runtime/issues/202),
 [#249](https://github.com/ValveSoftware/steam-runtime/issues/249))
+
+The `scout_layered_slim` beta branch improves compatibility with
+games that assume a newer environment than pure scout, by providing
+an environment that is a mixture of Steam Runtime 2 'soldier' and
+Steam Runtime 1 'scout'. Most games that work on Debian 10 should
+also work in this environment. However, due to a Steam limitation,
+after switching to or from this branch, it is necessary to exit from
+Steam completely and re-launch Steam, so that the updated compatibility
+tool configuration will be loaded.
 
 Reporting other issues
 ----------------------


### PR DESCRIPTION
* known-issues: Mention flatpak#4286

* reporting-bugs: Ask for SteamLinuxRuntime version numbers

* known-issues: Suggest the Flatpak app as a workaround for non-FHS hosts

* known-issues: Mention unprivileged_userns_clone=0 conflict with Flatpak
    
    A setuid version of bwrap is enough to make pressure-vessel work, but
    is not enough for it to work when used in conjunction with Flatpak.

* known-issues: Mention scout_layered_slim
    
    This avoids some issues in games that assume a newer-than-scout
    environment, but it has a different toolmanifest.vdf, which Steam does
    not currently reload automatically after a depot is changed.