### PR TITLE
Considerably speedup the setup phase

### DIFF
--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -182,7 +182,7 @@ pin_newer_runtime_libs ()
         host_soname_symlink=""
         bitness="unknown"
 
-        soname=$(basename "$soname_symlink")
+        soname=${soname_symlink##*/}
 
         # If we had entries in our arrays, get them
         if [[ -n "${host_libraries_32[$soname]+isset}" ||


### PR DESCRIPTION
- setup: Use parameter expansion instead of basename
    By switching to the bash parameter expansion we have a speedup of nearly
1 second on recent desktop systems with NVME, and probably more on
slower systems.

    They are not exactly the same, but here we are using a somewhat
controlled input, `find` of libraries in the absolute path of the steam
runtime, so it should not give us unexpected results.

- setup: Start to use the executable from steam-runtime if available
    The constant context switch to call the external command `file -L`
thousands of times makes the whole setup last several seconds.

    steam-runtime-tools provides a new executable that gathers the libraries
list from ldconfig, or from a specified directory, and prints in output
their word size, all in one go.

    By using this new method the execution time dropped from the previous
6.70 seconds to just 0.55 seconds.

    We still leave the older method as a fallback if the newer executable
has not being found.

This is still a WIP, the patch for `steam-runtime-tools.git` should be reviewed and merged first.
While this PR seems to be working fine on my system I still need to do some manual testing on different OSs, especially older ones and benchmark the execution speed on slower systems.

/cc @smcv 