### PR TITLE
run.sh: Handle STEAM_COMPAT_FLAGS environment variable

### DIFF
--- a/templates/run.sh
+++ b/templates/run.sh
@@ -103,6 +103,14 @@ host_library_paths="$STEAM_RUNTIME/pinned_libs_32:$STEAM_RUNTIME/pinned_libs_64:
 
 steam_runtime_library_paths="$host_library_paths$STEAM_RUNTIME/lib/i386-linux-gnu:$STEAM_RUNTIME/usr/lib/i386-linux-gnu:$STEAM_RUNTIME/lib/x86_64-linux-gnu:$STEAM_RUNTIME/usr/lib/x86_64-linux-gnu:$STEAM_RUNTIME/lib:$STEAM_RUNTIME/usr/lib"
 
+if [[ -n "${STEAM_COMPAT_INSTALL_PATH-}" && -n "${STEAM_COMPAT_FLAGS-}" ]]; then
+    case ",$STEAM_COMPAT_FLAGS," in
+        (*,search-cwd,*)
+            steam_runtime_library_paths="${steam_runtime_library_paths}:${STEAM_COMPAT_INSTALL_PATH}"
+            ;;
+    esac
+fi
+
 if [ "$1" = "--print-steam-runtime-library-paths" ]; then
     echo "$steam_runtime_library_paths"
     exit 0


### PR DESCRIPTION
Currently the only expected flag in `STEAM_COMPAT_FLAGS` is
`search-cwd`, that is used to append the game current working directory,
stored in `STEAM_COMPAT_INSTALL_PATH`, to the `LD_LIBRARY_PATH`.

Previously we handled this flag in pressure-vessel, but this may give
`STEAM_COMPAT_INSTALL_PATH` an higher priority than expected.
For example, when we are using the new layered scout runtime,
`STEAM_COMPAT_INSTALL_PATH` will be searched before the container
runtime's linker paths and the Steam Runtime's library paths.