### PR TITLE
templates: Use readlink -f instead of realpath

### DIFF
--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -27,7 +27,7 @@ pin_newer_runtime_libs ()
     local zenity_progress=true
 
     # First argument is the runtime path
-    steam_runtime_path=$(realpath "$1")
+    steam_runtime_path=$(readlink -f "$1")
 
     if [[ ! -d "$steam_runtime_path" ]]; then return; fi
 
@@ -370,7 +370,7 @@ check_pins ()
     local steam_runtime_path
 
     # First argument is the runtime path
-    steam_runtime_path=$(realpath "$1")
+    steam_runtime_path=$(readlink -f "$1")
 
     if [[ ! -d "$steam_runtime_path" ]]; then return; fi
 


### PR DESCRIPTION
realpath isn't Essential in very old Ubuntu releases (at least 14.04)
so there's no guarantee that it's available, whereas readlink has been
part of coreutils since time immemorial.