### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,17 @@ To prevent libraries from development and build machines 'leaking'
 into your applications, you should build within a Steam Runtime container
 or chroot environment.
 
-We recommend using a [Docker](https://docs.docker.com/get-docker/)
-or [rootless Podman](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md)
+We recommend using a
+[Toolbx](https://containertoolbx.org/),
+[rootless Podman](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md)
+or [Docker](https://docs.docker.com/get-docker/)
 container for this:
 
-    sudo docker pull registry.gitlab.steamos.cloud/steamrt/scout/sdk
+    podman pull registry.gitlab.steamos.cloud/steamrt/scout/sdk
 
 or
 
-    podman pull registry.gitlab.steamos.cloud/steamrt/scout/sdk
+    sudo docker pull registry.gitlab.steamos.cloud/steamrt/scout/sdk
 
 For more details, please consult the
 [Steam Runtime SDK](https://gitlab.steamos.cloud/steamrt/scout/sdk/-/blob/steamrt/scout/README.md)

--- a/doc/debug-symbols.md
+++ b/doc/debug-symbols.md
@@ -55,7 +55,7 @@ having difficulty with the PulseAudio libraries, similar to
 ## Getting the debug symbols for the host system
 
 This is the same as it would be without Steam. For a Debian, Ubuntu or
-SteamOS host, `apt install libc6-dbg:i386` is a good start. For
+SteamOS 2 host, `apt install libc6-dbg:i386` is a good start. For
 non-Debian-derived OSs, use whatever is the OS's usual mechanism to get
 detached debug symbols.
 

--- a/doc/goals.md
+++ b/doc/goals.md
@@ -297,8 +297,8 @@ uninstalled.
 
 Installing the Steam client should not be OS-specific:
 we don't want to have to build `.deb` packages for Debian, Ubuntu
-and SteamOS, `.rpm` packages for Fedora, *different* `.rpm` packages
-for openSUSE, and so on.
+and SteamOS 2, `.rpm` packages for Fedora, *different* `.rpm` packages
+for openSUSE, Pacman packages for Arch Linux and SteamOS 3, and so on.
 
 ### Steam can be installed unprivileged
 

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -74,7 +74,7 @@ The container runtime has the same
 [user namespace requirements](https://github.com/flatpak/flatpak/wiki/User-namespace-requirements)
 as Flatpak.
 
-On Debian 10 or older and SteamOS, either the `bubblewrap` package
+On Debian 10 or older and SteamOS 2, either the `bubblewrap` package
 from the OS must be installed, or the `kernel.unprivileged_userns_clone`
 sysctl parameter must be set to 1. Debian 11 will do this by default.
 

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -76,7 +76,8 @@ as Flatpak.
 
 On Debian 10 or older and SteamOS 2, either the `bubblewrap` package
 from the OS must be installed, or the `kernel.unprivileged_userns_clone`
-sysctl parameter must be set to 1. Debian 11 will do this by default.
+sysctl parameter must be set to 1. Debian 11 sets
+`kernel.unprivileged_userns_clone` to 1 by default.
 
 Similarly, on Arch Linux with the non-default `linux-hardened`
 kernel, either the `bubblewrap-suid` package must be installed, or the

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -54,18 +54,20 @@ believed to work successfully. The changes
 made to support these operating systems can be used as a basis to propose
 patches to make pressure-vessel work in other "almost-FHS" environments.
 
-NixOS has its own scripts to set up a FHS-compatible environment to
-run Steam. As of early 2021, very recent versions of this should be
-mostly compatible with pressure-vessel, but some system configurations
-are still problematic.
-
+NixOS has its own scripts to set up a FHS-compatible environment to run
+Steam. As of 2022, this should generally be compatible with pressure-vessel.
 Guix is in the same situation as NixOS.
 
 Other non-FHS distributions might also not work.
+We have prepared a document listing
+[assumptions made about the distribution][distro assumptions], which
+distribution developers might find useful.
 
 Workaround: don't enable SteamLinuxRuntime or Proton 5.13 (or newer)
 on OSs with unusual directory layouts, or use the unofficial Flatpak app
 (requires Flatpak 1.12).
+
+[distro assumptions]: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/HEAD/docs/distro-assumptions.md
 
 kernel.unprivileged\_userns\_clone
 ----------------------------------


### PR DESCRIPTION
* doc: Update to reflect SteamOS 3 not being Debian-derived
    
    SteamOS versions 1 and 2 were derived from older releases of Debian, so
    we have generally grouped it together with older Debian releases when
    talking about compatibility. It is now public that SteamOS 3, as used on
    the Steam Deck, is derived from Arch Linux instead, and as a result it
    behaves more like a recent version of Arch Linux than like an old version
    of Debian; update documentation to match this.

* doc: Talk about Debian 11 in the present tense
    
    At the time this paragraph was written, Debian 10 was the stable release
    and Debian 11 was a future release; now Debian 11 is the current stable
    release and Debian 10 is heading for end-of-life.

* known-issues: Point to distro-assumptions document
    
    This is specifically distro-maintainer-facing.

* README: Put more emphasis on Toolbx
    
    Now that the GA version of Steam includes a scout runtime whose
    corresponding SDK image is Toolbx-friendly, pointing developers towards
    Toolbx gives them many of the same convenience features we used to get
    from schroot, without needing to be "real root".