### PR TITLE
Documentation updates

### DIFF
--- a/doc/possible-designs.md
+++ b/doc/possible-designs.md
@@ -313,9 +313,12 @@ Does not solve:
     |  .  |          \- The game
 
 This design is used by the "Steam Linux Runtime - soldier" compatibility
-tool, currently used to run Proton 5.13 or later. It could potentially be
-used to run native Linux games in future, if Steam gains a way to mark
-games as targeting scout rather than soldier.
+tool to run Proton 5.13 or later.
+
+This design is also used by some native Linux games, to run in the
+"Steam Linux Runtime - sniper" compatibility tool.
+Early adopters include Battle for Wesnoth (1.17.x branch) and Retroarch.
+We expect that more native Linux games will be set up like this in future.
 
 This is also what the "Steam Linux Runtime" compatibility tool did
 until mid July 2021, but with a scout container instead of a soldier
@@ -337,8 +340,12 @@ However, games run in a container via the pressure-vessel tool:
       - host system, unrestricted
       - a private directory like ~/.var/app/com.steampowered.App440 per game
 
-As currently deployed, the container runtime is soldier, but it could
-be anything.
+The container runtime can be any source of shared libraries with a suitable
+balance between being up-to-date and being long-term-stable.
+The "Steam Linux Runtime - soldier" compatibility tool uses container
+runtime libraries from Steam Runtime 2 (soldier), based on Debian 10 (2019).
+The "Steam Linux Runtime - sniper" compatibility tool uses container
+runtime libraries from Steam Runtime 3 (sniper), based on Debian 11 (2021).
 
 Entirely solves:
 

--- a/doc/reporting-steamlinuxruntime-bugs.md
+++ b/doc/reporting-steamlinuxruntime-bugs.md
@@ -8,7 +8,13 @@ It consists of:
 * pressure-vessel, a container launching tool
 * a *runtime*, providing a set of libraries for games to use
 
-There are currently two runtimes available:
+There are currently three runtimes available:
+
+* [Steam Runtime 3 'sniper'](https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/sniper/README.md),
+    [app ID 1628350](https://steamdb.info/app/1628350/)
+    is used to run a few native Linux games such as Battle for Wesnoth
+    (1.17.x branch) and Retroarch.
+    We expect it to be used for other newer native Linux games in future.
 
 * [Steam Runtime 2 'soldier'](https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/soldier/README.md),
     [app ID 1391110](https://steamdb.info/app/1391110/)
@@ -128,7 +134,8 @@ select a different branch from your Steam Library, in the same way
 you would for a game: follow the same procedure as
 <https://support.steampowered.com/kb_article.php?ref=9847-WHXC-7326>,
 but instead of the properties of CS:GO, change the properties of the
-tool named *Steam Linux Runtime - soldier* or *Steam Linux Runtime*.
+tool named *Steam Linux Runtime - sniper*, *Steam Linux Runtime - soldier*
+or *Steam Linux Runtime*.
 
 The branches that are usually available are:
 
@@ -155,6 +162,7 @@ If something works in one branch but fails in another branch, that's
 very useful information to include in issue reports. Please be as clear
 as you can about which version works and which version fails. You can
 check the current version by looking at
+`SteamLinuxRuntime_sniper/VERSIONS.txt`,
 `SteamLinuxRuntime_soldier/VERSIONS.txt` or
 `SteamLinuxRuntime/VERSIONS.txt`.
 

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -24,9 +24,9 @@ the container runtimes, you will need:
 
 * Flatpak 1.12
 
-    * Ubuntu users can get this from
+    * Ubuntu 18.04 and 20.04 users can get this from
         [the PPA](https://launchpad.net/~flatpak/+archive/ubuntu/stable/),
-        and it will be included in Ubuntu 22.04 LTS
+        and it is included in Ubuntu 22.04 LTS
     * Debian 11 users can get this from
         [official backports](https://backports.debian.org/Instructions/),
         and it will be included in Debian 12

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -232,8 +232,19 @@ shared between the real system and the container:
 * the installation directory for Steam itself
 * the shader cache
 
+Since the 2022-08-04 beta release of "Steam Linux Runtime - soldier"
+and "Steam Linux Runtime - sniper", the following paths are also
+shared:
+
+* `/home`
+* `/media`
+* `/mnt`
+* `/opt`
+* `/run/media`
+* `/srv`
+
 However, directories outside those areas are usually not shared with
-the container. In particular, this affects games that ask you to browse
+the container. In particular, this can affect games that ask you to browse
 for a directory to be used for storage, like Microsoft Flight Simulator.
 
 You can force them to be shared by setting the environment variable
@@ -245,7 +256,7 @@ to a colon-separated list of paths. Paths in
 Example:
 
     export PRESSURE_VESSEL_FILESYSTEMS_RO="$MANGOHUD_CONFIGFILE"
-    export PRESSURE_VESSEL_FILESYSTEMS_RW="/media/ssd:/media/hdd"
+    export PRESSURE_VESSEL_FILESYSTEMS_RW="/hdd:/archival:/stuff/games"
     steam
 
 Symbolic links between directories

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -75,6 +75,8 @@ kernel.unprivileged\_userns\_clone
 The container runtime has the same
 [user namespace requirements](https://github.com/flatpak/flatpak/wiki/User-namespace-requirements)
 as Flatpak.
+Modern operating systems in their default configuration usually meet these
+requirements.
 
 On Debian 10 or older and SteamOS 2, either the `bubblewrap` package
 from the OS must be installed, or the `kernel.unprivileged_userns_clone`

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -268,7 +268,8 @@ for system-level directories (outside the home directory).
 
 If a directory that will be shared with the container is a symbolic link
 to some other directory, please make sure that the target of the symbolic
-link is also in a directory that is shared with the container.
+link is also in a directory that is
+[shared with the container](#sharing-directories-with-the-container).
 
 When using Proton, please avoid using symbolic links to redirect part of
 an emulated Windows drive to a different location. This can easily break


### PR DESCRIPTION
* Update status of sniper to reflect it starting to be used in production
* Update status of shared non-home directories to reflect yesterday's beta update
* Update release status of Flatpak 1.12
* Add another cross-link between sections
* Update status of kernel.unprivileged_userns_clone in modern distros