### PR TITLE
Documentation updates

### DIFF
--- a/doc/reporting-steamlinuxruntime-bugs.md
+++ b/doc/reporting-steamlinuxruntime-bugs.md
@@ -18,8 +18,7 @@ There are currently three runtimes available:
 
 * [Steam Runtime 2 'soldier'](https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/soldier/README.md),
     [app ID 1391110](https://steamdb.info/app/1391110/)
-    is used to run official releases of Proton 5.13 or newer. It might be used
-    for newer native Linux games in future.
+    is used to run official releases of Proton 5.13 or newer.
 
     It is also used to run native Linux games that target
     Steam Runtime 1 'scout', if the "Steam Linux Runtime" compatibility

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -233,11 +233,6 @@ shared between the real system and the container:
 * the directory containing Proton, if used
 * the installation directory for Steam itself
 * the shader cache
-
-Since the 2022-08-04 beta release of "Steam Linux Runtime - soldier"
-and "Steam Linux Runtime - sniper", the following paths are also
-shared:
-
 * `/home`
 * `/media`
 * `/mnt`
@@ -245,9 +240,11 @@ shared:
 * `/run/media`
 * `/srv`
 
-However, directories outside those areas are usually not shared with
+Directories outside those areas are usually not shared with
 the container. In particular, this can affect games that ask you to browse
-for a directory to be used for storage, like Microsoft Flight Simulator.
+for a directory to be used for storage, like Microsoft Flight Simulator,
+if your large storage directory is mounted at a custom location such
+as `/hdd`.
 
 You can force them to be shared by setting the environment variable
 `PRESSURE_VESSEL_FILESYSTEMS_RO` and/or `PRESSURE_VESSEL_FILESYSTEMS_RW`


### PR DESCRIPTION
* doc: soldier is not planned to be used for native Linux games
    
    As per https://github.com/ValveSoftware/steam-for-linux/issues/7430,
    the intention is that native Linux games requiring a newer runtime
    that scout will standardize on sniper (Debian-11-based), skipping
    the older soldier runtime (Debian-10-based) which is only used
    for Proton.

* known-issues: Update status of removable media directories
    
    The early August betas of soldier and sniper have now been promoted to
    stable status, so we don't need to be so conditional about this.