### PR TITLE
doc: Update default branch reference for steam-runtime-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ More information about the
 [container runtime][] is available as part of the
 [steam-runtime-tools documentation][].
 
-[LD_LIBRARY_PATH runtime]: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/master/docs/ld-library-path-runtime.md
-[container runtime]: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/HEAD/docs/container-runtime.md
+[LD_LIBRARY_PATH runtime]: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/ld-library-path-runtime.md
+[container runtime]: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/container-runtime.md
 [Proton]: https://github.com/ValveSoftware/Proton/
-[steam-runtime-tools documentation]: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/tree/master/docs
+[steam-runtime-tools documentation]: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/tree/main/docs
 
 Reporting bugs and issues
 -------------------------

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -67,7 +67,7 @@ Workaround: don't enable SteamLinuxRuntime or Proton 5.13 (or newer)
 on OSs with unusual directory layouts, or use the unofficial Flatpak app
 (requires Flatpak 1.12).
 
-[distro assumptions]: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/HEAD/docs/distro-assumptions.md
+[distro assumptions]: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/distro-assumptions.md
 
 kernel.unprivileged\_userns\_clone
 ----------------------------------


### PR DESCRIPTION
The default branch has been renamed to `main`, and our earlier attempts to provide branch-independent links were thwarted by [a Gitlab regression](https://gitlab.com/gitlab-org/gitlab/-/issues/371973).