### PR TITLE
Documentation updates

### DIFF
--- a/doc/goals.md
+++ b/doc/goals.md
@@ -272,7 +272,7 @@ invented when the runtime's base distribution was released.
 ### i386 games work on non-i386 hosts
 
 Older games were compiled for the IA32 ABI (e.g. Debian i386).
-They should work on modern x86-64 systems (e.g. Debian amd64) even
+They should ideally work on modern x86-64 systems (e.g. Debian amd64) even
 if the modern system *does not* provide basic i386 packages like
 glibc and graphics drivers, as long as the container runtime *does*.
 

--- a/doc/goals.md
+++ b/doc/goals.md
@@ -15,7 +15,7 @@ These are things that are already more or less true in the
 ### Old games continue to work
 
 Older games like Half-Life and Portal, developed circa Ubuntu 12.04,
-must work on modern systems like Ubuntu 20.04 without needing ongoing
+must work on modern systems like Ubuntu 22.04 without needing ongoing
 maintenance.
 
 This is particularly important in cases like Torchlight where the
@@ -62,10 +62,10 @@ or the AMD Radeon series), games should work on it.
 
 For recent GPUs, this means the game must be able to use a suitably
 recent driver version that supports the GPU: for example, we cannot
-expect a 2021 GPU to be supported by a 2012 version of Mesa.
+expect a 2023 GPU to be supported by a 2012 version of Mesa.
 
 Meeting this goal is likely to be particularly problematic in designs
-that would require us to compile a 2021 graphics driver in the 2012
+that would require us to compile a 2023 graphics driver in the 2012
 runtime/SDK environment.
 
 ### Proprietary (NVIDIA) graphics drivers continue to work
@@ -104,15 +104,15 @@ introduce a new runtime for games and support it longer-term, we should
 aim higher than 2015.
 
 Steam Runtime version 2, 'soldier', is based on Debian 10 'buster',
-released in 2019. It is used to run Proton 5.13 and later versions.
-Running native Linux games in a "pure" soldier container is not
-currently possible, but would be a good improvement.
+released in 2019. It is used to run Proton 5.13 up to 7.0.
 
 Steam Runtime version 3, 'sniper', is based on Debian 11 'bullseye',
 released in 2021. It is otherwise similar to soldier.
+It is used to run Proton 8.0 or later, and some native Linux games
+such as Dota 2, Endless Sky and Retroarch.
 
 Similarly, Steam Runtime version 4, 'medic', is likely to be based on
-Debian 12 'bookworm', which is expected to be released in 2023.
+Debian 12 'bookworm', which was released in 2023.
 
 #### New glibc
 

--- a/doc/goals.md
+++ b/doc/goals.md
@@ -180,7 +180,7 @@ same ELF `DT_SONAME`) but are in fact not compatible, for example:
     feature or dependency can result in symbols disappearing from
     its ABI, resulting in games that reference those symbols crashing
 
-- There is a fairly subtle interaction between libdbus,
+- There is a fairly subtle interaction between
     libdbusmenu-gtk, libdbusmenu-glib and Ubuntu's patched GTK 2
     that has resulted in these libraries being forced to be taken
     from the Steam Runtime, to avoid breaking the Unity dock

--- a/doc/possible-designs.md
+++ b/doc/possible-designs.md
@@ -313,11 +313,12 @@ Does not solve:
     |  .  |          \- The game
 
 This design is used by the "Steam Linux Runtime - soldier" compatibility
-tool to run Proton 5.13 or later.
+tool to run Proton 5.13 up to 7.0, and the "Steam Linux Runtime - sniper"
+compatibility tool to run Proton 8.0 or later.
 
 This design is also used by some native Linux games, to run in the
 "Steam Linux Runtime - sniper" compatibility tool.
-Early adopters include Battle for Wesnoth (1.17.x branch) and Retroarch.
+Early adopters include Dota 2, Endless Sky and Retroarch.
 We expect that more native Linux games will be set up like this in future.
 
 This is also what the "Steam Linux Runtime" compatibility tool did
@@ -747,7 +748,7 @@ and how it would work. For old (scout) games, it could be:
     [2018 `LD_LIBRARY_PATH` scout runtime + pressure-vessel container](#pressure-vessel-2019)
     above, with graphics drivers from the host system or a Flatpak runtime
     (presumably the same one the Steam client uses)
-  * a Steam Runtime 2 container with the `LD_LIBRARY_PATH`
+  * a Steam Runtime 2 or 3 container with the `LD_LIBRARY_PATH`
     scout runtime inside, similar to
     [2018 `LD_LIBRARY_PATH` scout runtime + newer Platform + scout again](#pressure-vessel-scout-on-srt2)
     above, with graphics drivers from the host system or a Flatpak runtime
@@ -755,17 +756,17 @@ and how it would work. For old (scout) games, it could be:
   * a Flatpak runtime with the `LD_LIBRARY_PATH`
     scout runtime inside, similar to
     [2018 `LD_LIBRARY_PATH` scout runtime + newer Platform + scout again](#pressure-vessel-scout-on-srt2)
-    above but using a Flatpak runtime instead of Steam Runtime 2, with
+    above but using a Flatpak runtime instead of Steam Runtime 2 or 3, with
     graphics drivers from the host system or that same Flatpak runtime
 
-and for new (Steam Runtime 2) games, it could be:
+and for new (Steam Runtime 2 or 3) games, it would be:
 
-  * a pure Steam Runtime 2 container,
+  * a pure Steam Runtime 2 or 3 container,
     [2018 `LD_LIBRARY_PATH` scout runtime + pressure-vessel container](#pressure-vessel-2019),
     with graphics drivers from the host system or a Flatpak runtime
     (as of mid July 2021, this is what is implemented in practice)
   * a Flatpak runtime with an `LD_LIBRARY_PATH`
-    Steam Runtime 2 runtime inside, analogous to
+    Steam Runtime 2 or 3 runtime inside, analogous to
     [Layered `LD_LIBRARY_PATH` runtime](#layered-ldlp) above,
     with graphics drivers from the host system or that same
     Flatpak runtime
@@ -809,7 +810,7 @@ Flatpak 1.12 or later and Proton >= 5.13.
     |  flatpak-portal service <===== IPC from pressure-vessel-wrap
     |       |
     |  |----\-bwrap-----
-    |  |       |      Steam Runtime 2
+    |  |       |      Steam Runtime 2 or 3
     |  |       |
     |  |       \- Proton, if used
     |  |          \- The game

--- a/doc/reporting-steamlinuxruntime-bugs.md
+++ b/doc/reporting-steamlinuxruntime-bugs.md
@@ -12,13 +12,13 @@ There are currently three runtimes available:
 
 * [Steam Runtime 3 'sniper'](https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/sniper/README.md),
     [app ID 1628350](https://steamdb.info/app/1628350/)
-    is used to run a few native Linux games such as Battle for Wesnoth
-    (1.17.x branch) and Retroarch.
+    is used to run official releases of Proton 8.0 or newer,
+    and some native Linux games such as Dota 2, Endless Sky and Retroarch.
     We expect it to be used for other newer native Linux games in future.
 
 * [Steam Runtime 2 'soldier'](https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/soldier/README.md),
     [app ID 1391110](https://steamdb.info/app/1391110/)
-    is used to run official releases of Proton 5.13 or newer.
+    is used to run official releases of Proton versions 5.13 to 7.0.
 
     It is also used to run native Linux games that target
     Steam Runtime 1 'scout', if the "Steam Linux Runtime" compatibility

--- a/doc/reporting-steamlinuxruntime-bugs.md
+++ b/doc/reporting-steamlinuxruntime-bugs.md
@@ -190,7 +190,7 @@ If you know your way around a Linux system, including using terminal
 commands, there are a few things you can try to help us get more
 information about games that aren't working.
 
-### <a name="test-ui" id="test-ui">The test-UI</a>
+### <a name="test-ui" id="test-ui">The test-UI (steam-runtime-launch-options)</a>
 
 pressure-vessel has a very basic user interface for testing and debugging.
 This is a control panel for advanced options, most of which will break
@@ -199,8 +199,9 @@ for everyone already. Use it at your own risk!
 
 To enable this, install PyGObject and the GLib and GTK 3
 GObject-Introspection data (that's `python3-gi` and `gir1.2-gtk-3.0` on
-Debian-derived systems), then run Steam with the `PRESSURE_VESSEL_WRAP_GUI`
-environment variable set to `1`.
+Debian-derived systems), then set a game's launch options to:
+
+    steam-runtime-launch-options -- %command%
 
 This mode does not work in situations where pressure-vessel would have
 been run non-interactively, such as for *Help -> System Information*

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -5,6 +5,36 @@ Some issues involving the SteamLinuxRuntime framework and the
 pressure-vessel container-launcher are not straightforward to fix.
 Here are some that are likely to affect multiple users:
 
+Labelling of Steam Linux Runtime versions
+-----------------------------------------
+
+The naming used for the various branches of the Steam Linux Runtime is
+not always obvious.
+
+The term "Steam Play" is used in the Steam user interface to refer to
+all compatibility tools, including
+the Steam container runtime framework
+(a mechanism to run native Linux games on older or newer Linux distributions),
+Proton (a mechanism to run Windows games on Linux),
+and potentially other compatibility tools in future.
+
+The term "Steam Linux Runtime" is used in the Steam user interface to refer
+to the container runtime framework.
+
+The "Steam Linux Runtime" compatibility tool (application ID 1070560) is
+actually Steam Linux Runtime version 1,
+which combines Steam Runtime 1 libraries with a Steam Runtime 2 container,
+and is used to run historical native Linux games.
+
+The "Steam Linux Runtime - soldier" tool (application ID 1391110) is
+Steam Linux Runtime version 2,
+which is used to run Proton 5.13 up to 7.0 and is also used internally
+by the "Steam Linux Runtime" tool.
+
+The "Steam Linux Runtime - sniper" tool (application ID 1628350) is
+Steam Linux Runtime version 3,
+which is used to run Proton 8.0 and some newer native Linux games.
+
 Disabling Steam Play disables all Steam Linux Runtime tools
 -----------------------------------------------------------
 

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -85,6 +85,19 @@ ensure that "Force the use of a specific compatibility tool" is unchecked.
 
 ([steam-for-linux#9844](https://github.com/ValveSoftware/steam-for-linux/issues/9844))
 
+libbz2 on Fedora
+----------------
+
+If the `nvidia-vaapi-driver` package is installed on a Fedora-derived
+system, then games that depend on `libbz2.so.1.0` and use a Steam
+Linux Runtime-based environment, such as Dota 2, will fail to start.
+This is a container runtime framework issue, which will be fixed in a
+future release.
+
+Workaround: uninstall `nvidia-vaapi-driver`.
+
+([Dota-2#2392](https://github.com/ValveSoftware/Dota-2/issues/2392))
+
 Flatpak
 -------
 

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -5,6 +5,56 @@ Some issues involving the SteamLinuxRuntime framework and the
 pressure-vessel container-launcher are not straightforward to fix.
 Here are some that are likely to affect multiple users:
 
+Disabling Steam Play disables all Steam Linux Runtime tools
+-----------------------------------------------------------
+
+In Steam's global settings, there is an option to turn off all Steam Play
+compatibility tools.
+As well as disabling Proton, this also disables Steam Linux Runtime version 3
+(sniper), which will result in games that require this runtime being
+launched in a way that does not work.
+This is a Steam client issue: it should not allow launching the affected
+games in this configuration.
+
+Games affected by this include Dota 2, Endless Sky and Retroarch.
+
+Workaround: in Steam's global Settings window, go to the Compatibility tab
+and ensure that "Enable Steam Play for supported titles" is checked.
+
+([steam-for-linux#9852](https://github.com/ValveSoftware/steam-for-linux/issues/9852))
+
+Switching Steam Linux Runtime branch sometimes requires a Steam restart
+-----------------------------------------------------------------------
+
+When a game that was previously using an older runtime environment switches
+to Steam Linux Runtime version 3 (sniper), sometimes the Steam client will
+continue to run that game in the older runtime until it is restarted.
+This is a Steam client issue: it should switch to the new runtime
+automatically.
+
+Games affected by this include Dota 2, Endless Sky and Retroarch.
+
+Workaround: allow Steam to download the updated game, then completely exit
+from Steam, and launch Steam again. This will only need to be done once:
+all subsequent game launches should work correctly.
+
+([steam-for-linux#9835](https://github.com/ValveSoftware/steam-for-linux/issues/9835))
+
+Forcing use of Steam Linux Runtime 1 for games requiring SLR 3
+--------------------------------------------------------------
+
+It is currently possible for users to configure games to be run
+under Steam Linux Runtime version 1, even if the game requires
+Steam Linux Runtime version 3 (sniper), which often will not work.
+This is a Steam client issue: it should not allow this configuration.
+
+Games affected by this include Dota 2, Endless Sky and Retroarch.
+
+Workaround: in the game's Properties, go to the Compatibility tab and
+ensure that "Force the use of a specific compatibility tool" is unchecked.
+
+([steam-for-linux#9844](https://github.com/ValveSoftware/steam-for-linux/issues/9844))
+
 Flatpak
 -------
 


### PR DESCRIPTION
* goals: Update time/version-sensitive text
    
    Debian 12 was released, Ubuntu 22.04 is now current, and Dota 2 and
    Proton 8.0 now use Steam Runtime 3 'sniper'.

* goals: Update list of libraries involved with tray icons
    
    We were able to remove libdbus from this list.

* goals: "i386 games work on non-i386 hosts" is not possible short-term
    
    Steam currently requires at least an i386 glibc and i386 GPU drivers,
    and so does the container runtime framework. Adjust the wording here
    to reflect our longer-term goal of not needing those things not being
    a top priority.

* possible-designs: Adjust version-dependent text

* reporting-bugs: Mention steam-runtime-launch-options instead of pv-test-ui
    
    The steam-runtime-launch-options tool has superseded pv-test-ui, which
    is no longer shipped in newer versions of SLR. The way to activate this
    tool is slightly different.

* reporting-bugs: Describe wider use of sniper in 2023

* known-issues: Mention Steam client issues that impact Dota 2
    
    Switching Dota 2 from SLR 1 to SLR 3 revealed a few Steam client issues
    that could result in it being run under the wrong runtime. Describe
    their workarounds.

* known-issues: Clarify versioning of SLR tools
    
    The user-facing names of these tools are somewhat confusing, using
    codenames (or no version information at all) rather than version numbers.
    
* known-issues: Mention Dota-2#2392