### PR TITLE
docs: Update for renaming of Steam Linux Runtime compat tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ downloaded to your Steam library if you install a game or a version of
 Proton that requires it.
 They can also be downloaded by opening `steam://` links with Steam:
 
-* Steam Linux Runtime (scout-compatible): `steam steam://install/1070560`
-* Steam Linux Runtime - soldier: `steam steam://install/1391110`
-* Steam Linux Runtime - sniper: `steam steam://install/1628350`
+* Steam Linux Runtime 1.0 (scout): `steam steam://install/1070560`
+* Steam Linux Runtime 2.0 (soldier): `steam steam://install/1391110`
+* Steam Linux Runtime 3.0 (sniper): `steam steam://install/1628350`
 
 All the software that makes up the Steam Runtime is available in both source and binary form in the Steam Runtime repository [https://repo.steampowered.com/steamrt](https://repo.steampowered.com/steamrt "")
 

--- a/doc/possible-designs.md
+++ b/doc/possible-designs.md
@@ -312,16 +312,16 @@ Does not solve:
     |  .  |       \- Proton (if used)
     |  .  |          \- The game
 
-This design is used by the "Steam Linux Runtime - soldier" compatibility
-tool to run Proton 5.13 up to 7.0, and the "Steam Linux Runtime - sniper"
+This design is used by the "Steam Linux Runtime 2.0 (soldier)" compatibility
+tool to run Proton 5.13 up to 7.0, and the "Steam Linux Runtime 3.0 (sniper)"
 compatibility tool to run Proton 8.0 or later.
 
 This design is also used by some native Linux games, to run in the
-"Steam Linux Runtime - sniper" compatibility tool.
+"Steam Linux Runtime 3.0 (sniper)" compatibility tool.
 Early adopters include Dota 2, Endless Sky and Retroarch.
 We expect that more native Linux games will be set up like this in future.
 
-This is also what the "Steam Linux Runtime" compatibility tool did
+This is also what the "Steam Linux Runtime 1.0 (scout)" compatibility tool did
 until mid July 2021, but with a scout container instead of a soldier
 container. Since mid July 2021,
 [a different design](#pressure-vessel-scout-on-srt2)
@@ -343,9 +343,9 @@ However, games run in a container via the pressure-vessel tool:
 
 The container runtime can be any source of shared libraries with a suitable
 balance between being up-to-date and being long-term-stable.
-The "Steam Linux Runtime - soldier" compatibility tool uses container
+The "Steam Linux Runtime 2.0 (soldier)" compatibility tool uses container
 runtime libraries from Steam Runtime 2 (soldier), based on Debian 10 (2019).
-The "Steam Linux Runtime - sniper" compatibility tool uses container
+The "Steam Linux Runtime 3.0 (sniper)" compatibility tool uses container
 runtime libraries from Steam Runtime 3 (sniper), based on Debian 11 (2021).
 
 Entirely solves:
@@ -611,7 +611,7 @@ Would not solve:
 
 ## <a name="pressure-vessel-scout-on-srt2">2018 `LD_LIBRARY_PATH` scout runtime + newer Platform + scout again</a>
 
-This design is used by the "Steam Linux Runtime" compatibility
+This design is used by the "Steam Linux Runtime 1.0 (scout)" compatibility
 tool since mid July 2021. It is referred to internally as the
 "scout-on-soldier" runtime.
 
@@ -867,7 +867,7 @@ Does not solve:
 
 ### Steam Runtime 2 container with `LD_LIBRARY_PATH` runtime inside
 
-This design is used by the "Steam Linux Runtime" compatibility
+This design is used by the "Steam Linux Runtime 1.0 (scout)" compatibility
 tool since mid July 2021, when combined with Flatpak 1.12 or later.
 
     |----------------------------

--- a/doc/reporting-steamlinuxruntime-bugs.md
+++ b/doc/reporting-steamlinuxruntime-bugs.md
@@ -10,21 +10,21 @@ It consists of:
 
 There are currently three runtimes available:
 
-* [Steam Runtime 3 'sniper'](https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/sniper/README.md),
+* [Steam Linux Runtime 3.0 (sniper)](https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/sniper/README.md),
     [app ID 1628350](https://steamdb.info/app/1628350/)
     is used to run official releases of Proton 8.0 or newer,
     and some native Linux games such as Dota 2, Endless Sky and Retroarch.
     We expect it to be used for other newer native Linux games in future.
 
-* [Steam Runtime 2 'soldier'](https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/soldier/README.md),
+* [Steam Linux Runtime 2.0 (soldier)](https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/soldier/README.md),
     [app ID 1391110](https://steamdb.info/app/1391110/)
     is used to run official releases of Proton versions 5.13 to 7.0.
 
     It is also used to run native Linux games that target
-    Steam Runtime 1 'scout', if the "Steam Linux Runtime" compatibility
-    tool is selected for them.
+    Steam Runtime 1 'scout', if the "Steam Linux Runtime 1.0 (scout)"
+    compatibility tool (formerly "Steam Linux Runtime") is selected for them.
 
-* [Steam Runtime 1 'scout'](https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/scout/README.md),
+* [Steam Linux Runtime 1.0 (scout)](https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/scout/README.md),
     [app ID 1070560](https://steamdb.info/app/1070560/)
     can be used on an opt-in basis to run native Linux games in a
     container. It uses the same libraries as the traditional
@@ -134,8 +134,9 @@ select a different branch from your Steam Library, in the same way
 you would for a game: follow the same procedure as
 <https://support.steampowered.com/kb_article.php?ref=9847-WHXC-7326>,
 but instead of the properties of CS:GO, change the properties of the
-tool named *Steam Linux Runtime - sniper*, *Steam Linux Runtime - soldier*
-or *Steam Linux Runtime*.
+tool named *Steam Linux Runtime 3.0 (sniper)*,
+*Steam Linux Runtime 2.0 (soldier)*
+or *Steam Linux Runtime 1.0 (scout)*.
 
 The branches that are usually available are:
 
@@ -238,7 +239,7 @@ and unpack the tarball into that directory so that you have files like
 `SteamLinuxRuntime_soldier/my_soldier_platform_0.20200604.0/files/bin/env`.
 Then select it from the list of runtimes in [the test-UI](#test-ui).
 
-For the "Steam Linux Runtime" scout environment, the closest equivalent
+For the "Steam Linux Runtime 1.0 (scout)" environment, the closest equivalent
 is to download a file named `steam-runtime.tar.xz` from
 from <https://repo.steampowered.com/steamrt-images-scout/snapshots/>
 and unpack it into the `SteamLinuxRuntime` directory, so that you have

--- a/doc/steamlinuxruntime-known-issues.md
+++ b/doc/steamlinuxruntime-known-issues.md
@@ -8,8 +8,8 @@ Here are some that are likely to affect multiple users:
 Labelling of Steam Linux Runtime versions
 -----------------------------------------
 
-The naming used for the various branches of the Steam Linux Runtime is
-not always obvious.
+The naming used for the various branches of the Steam Linux Runtime has
+not always been obvious.
 
 The term "Steam Play" is used in the Steam user interface to refer to
 all compatibility tools, including
@@ -19,28 +19,30 @@ Proton (a mechanism to run Windows games on Linux),
 and potentially other compatibility tools in future.
 
 The term "Steam Linux Runtime" is used in the Steam user interface to refer
-to the container runtime framework.
+to the container runtime framework specifically.
 
-The "Steam Linux Runtime" compatibility tool (application ID 1070560) is
-actually Steam Linux Runtime version 1,
-which combines Steam Runtime 1 libraries with a Steam Runtime 2 container,
+The "Steam Linux Runtime 1.0 (scout)" compatibility tool
+(application ID 1070560)
+combines Steam Runtime 1 libraries with a Steam Runtime 2 container,
 and is used to run historical native Linux games.
+Before September 2023, this was (confusingly) labelled "Steam Linux Runtime".
+The old name might still appear in some contexts.
 
-The "Steam Linux Runtime - soldier" tool (application ID 1391110) is
-Steam Linux Runtime version 2,
-which is used to run Proton 5.13 up to 7.0 and is also used internally
+The "Steam Linux Runtime 2.0 (soldier)" tool (application ID 1391110) is
+used to run Proton 5.13 up to 7.0 and is also used internally
 by the "Steam Linux Runtime" tool.
+Before September 2023, this was labelled "Steam Linux Runtime - soldier".
 
-The "Steam Linux Runtime - sniper" tool (application ID 1628350) is
-Steam Linux Runtime version 3,
-which is used to run Proton 8.0 and some newer native Linux games.
+The "Steam Linux Runtime 3.0 (sniper)" tool (application ID 1628350) is
+used to run Proton 8.0 and some newer native Linux games.
+Before September 2023, this was labelled "Steam Linux Runtime - sniper".
 
 Disabling Steam Play disables all Steam Linux Runtime tools
 -----------------------------------------------------------
 
 In Steam's global settings, there is an option to turn off all Steam Play
 compatibility tools.
-As well as disabling Proton, this also disables Steam Linux Runtime version 3
+As well as disabling Proton, this also disables Steam Linux Runtime 3.0
 (sniper), which will result in games that require this runtime being
 launched in a way that does not work.
 This is a Steam client issue: it should not allow launching the affected
@@ -57,7 +59,7 @@ Switching Steam Linux Runtime branch sometimes requires a Steam restart
 -----------------------------------------------------------------------
 
 When a game that was previously using an older runtime environment switches
-to Steam Linux Runtime version 3 (sniper), sometimes the Steam client will
+to Steam Linux Runtime 3.0 (sniper), sometimes the Steam client will
 continue to run that game in the older runtime until it is restarted.
 This is a Steam client issue: it should switch to the new runtime
 automatically.
@@ -70,12 +72,12 @@ all subsequent game launches should work correctly.
 
 ([steam-for-linux#9835](https://github.com/ValveSoftware/steam-for-linux/issues/9835))
 
-Forcing use of Steam Linux Runtime 1 for games requiring SLR 3
---------------------------------------------------------------
+Forcing use of Steam Linux Runtime 1.0 (scout) for games requiring SLR 3
+------------------------------------------------------------------------
 
 It is currently possible for users to configure games to be run
-under Steam Linux Runtime version 1, even if the game requires
-Steam Linux Runtime version 3 (sniper), which often will not work.
+under Steam Linux Runtime 1.0 (scout), even if the game requires
+Steam Linux Runtime 3.0 (sniper), which often will not work.
 This is a Steam client issue: it should not allow this configuration.
 
 Games affected by this include Dota 2, Endless Sky and Retroarch.
@@ -167,7 +169,7 @@ We have prepared a document listing
 [assumptions made about the distribution][distro assumptions], which
 distribution developers might find useful.
 
-Workaround: don't enable SteamLinuxRuntime or Proton 5.13 (or newer)
+Workaround: don't enable Steam Linux Runtime or Proton 5.13 (or newer)
 on OSs with unusual directory layouts, or use the unofficial Flatpak app
 (requires Flatpak 1.12).
 
@@ -335,7 +337,7 @@ Non-Steam games
 
 Non-Steam games are not currently supported.
 
-Workaround: don't use SteamLinuxRuntime for those games yet.
+Workaround: don't use Steam Linux Runtime for those games yet.
 
 ([#228](https://github.com/ValveSoftware/steam-runtime/issues/228))
 
@@ -424,13 +426,13 @@ experimental, and is not expected to work for all games. Native Linux
 games that were compiled for Steam Runtime 1 `scout` are intended to be
 run in the older `LD_LIBRARY_PATH`-based Steam Runtime.
 
-### Updating "Steam Linux Runtime" compatibility tool
+### Updating "Steam Linux Runtime 1.0 (scout)" compatibility tool
 
 Due to a Steam limitation, after updating to version 0.20210630.32 or
 later, it is necessary to exit from Steam completely and re-launch Steam,
 so that the updated compatibility tool configuration will be loaded.
 Until Steam has been restarted, trying to launch a game with the
-"Steam Linux Runtime" compatibility tool will show an error message
+"Steam Linux Runtime 1.0 (scout)" compatibility tool will show an error message
 asking for a Steam restart.
 
 Reporting other issues


### PR DESCRIPTION
* App 1070560: was SLR, now SLR 1.0 (scout)
* App 1391110: was SLR - soldier, now SLR 2.0 (soldier)
* App 1628350: was SLR - sniper, now SLR 3.0 (sniper)

The more generic name "Steam Linux Runtime" now refers to the whole container runtime ecosystem.

Helps: steamrt/tasks#320

cc @TTimo 