### PR TITLE
doc: Set both STEAM_RUNTIME_SCOUT and STEAM_RUNTIME for custom runtimes

### DIFF
--- a/doc/building-custom-runtime.md
+++ b/doc/building-custom-runtime.md
@@ -74,8 +74,9 @@ what appears in Help -> System Information in Steam, if your runtime is in
     ~/rttest/run.sh ~/rttest/usr/bin/steam-runtime-system-info
 
 Or to launch Steam itself (and any Steam applications) within your runtime,
-set the `STEAM_RUNTIME` environment variable to point to your runtime directory;
+set both the `STEAM_RUNTIME_SCOUT` and `STEAM_RUNTIME` environment variables
+to point to your runtime directory:
 
-    ~/.local/share/Steam$ STEAM_RUNTIME=~/rttest ./steam.sh
+    $ STEAM_RUNTIME_SCOUT=~/rttest STEAM_RUNTIME="$STEAM_RUNTIME_SCOUT" ./steam.sh
     Running Steam on ubuntu 14.04 64-bit
     STEAM_RUNTIME has been set by the user to: /home/username/rttest


### PR DESCRIPTION
Historically STEAM_RUNTIME has had a dual role as an unsupported developer/debugging input to steam.sh (to use a non-default runtime, or disable the scout runtime completely) and as an output from steam.sh (to indicate to games, libraries and utilities that they are running in the scout runtime).

This is quite confusing, so we're in the process of introducing a new variable STEAM_RUNTIME_SCOUT which can be set to the absolute path to a non-default runtime, and is unambiguously only an input: if it's set, that doesn't imply anything about whether you are inside the LDLP runtime or not. This was already used by the
"Steam Linux Runtime 1.0 (scout)" compatibility tool, which couldn't use STEAM_RUNTIME because that variable gets unset by the container runtime framework.

To be compatible with both old and new Steam, recommend setting both variables to the same value when using a custom runtime.

steamrt/tasks#520

---

Documentation only, no functional change. cc @TTimo 