### PR TITLE
Documentation updates, drop vestigial support for heavy

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ into your applications, you should build within a Steam Runtime container.
 
 We recommend using a
 [Toolbx](https://containertoolbx.org/),
+[Distrobox](https://distrobox.it/),
 [rootless Podman](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md)
 or [Docker](https://docs.docker.com/get-docker/)
 container for this.

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ but we now recommend that developers should target sniper instead.
 
 The Steam Runtime is also used by the [Proton][] Steam Play compatibility
 tools, which run Windows games on Linux systems.
-Older versions of Proton (5.0 or earlier) use the same 'scout'
-[`LD_LIBRARY_PATH` runtime][LD_LIBRARY_PATH runtime] as most native
-Linux games.
-Newer versions of Proton (5.13 or newer) use a [container runtime][]
-with newer library versions: this is Steam Runtime version 2, codenamed
-'soldier'.
+Current versions of Proton (8.0 or newer) use the Steam Runtime 3 'sniper'
+container runtime.
+Older versions of Proton (5.13, 6.3 and 7.0) use the
+Steam Runtime 2 'soldier' container runtime.
+The oldest versions of Proton (5.0 or earlier) use the legacy
+Steam Runtime 1 'scout' `LD_LIBRARY_PATH` runtime.
 
 More information about the
 [`LD_LIBRARY_PATH` runtime][LD_LIBRARY_PATH runtime] and

--- a/README.md
+++ b/README.md
@@ -9,17 +9,16 @@ Introduction
 The Linux version of Steam runs on many Linux distributions, ranging
 from the latest rolling-release distributions like Arch Linux to older
 LTS distributions like Ubuntu 16.04.
-To achieve this, it uses a special library stack, the *Steam Runtime*,
-which is installed in `~/.steam/root/ubuntu12_32/steam-runtime`.
+To achieve this, it uses a special library stack, the *Steam Runtime*.
+
+The original version of the Steam Runtime is installed in
+`~/.steam/root/ubuntu12_32/steam-runtime`.
 This is Steam Runtime version 1, codenamed `scout` after the Team
 Fortress 2 character class.
-
 The Steam client itself is run in an environment that adds the shared
 libraries from Steam Runtime 1 'scout' to the library loading path,
-using the `LD_LIBRARY_PATH` environment variable.
-This is referred to as the [`LD_LIBRARY_PATH` runtime][LD_LIBRARY_PATH runtime].
-Most native Linux games available through Steam are also run in this
-environment.
+using the `LD_LIBRARY_PATH` environment variable:
+this is referred to as the [`LD_LIBRARY_PATH` runtime][LD_LIBRARY_PATH runtime].
 
 A newer approach to cross-distribution compatibility is to use Linux
 namespace (container) technology, to run games in a more predictable
@@ -28,6 +27,29 @@ might be old, new or unusually set up.
 This is implemented as a series of Steam Play compatibility tools, and
 is referred to as the Steam [container runtime][], or as the
 *Steam Linux Runtime*.
+
+Newer native Linux games such as Counter-Strike 2 and Dota 2
+run in an environment referred to as `Steam Linux Runtime 3.0 (sniper)`,
+which is a [Steam Runtime 3 'sniper'][sniper] container.
+This is the recommended environment for developers of new native Linux games.
+To target this environment,
+developers should compile their games in the [sniper SDK][],
+then set up a Launch Option that supports Linux,
+and use the Installation → Linux Runtime menu item in the Steamworks
+partner web interface to select the sniper runtime.
+
+Older native Linux games normally run in an environment referred to as
+`Steam Linux Runtime 1.0 (scout)`, which is a
+[Steam Runtime 2 'soldier'][soldier] container combined with the
+Steam Runtime 1 'scout' [`LD_LIBRARY_PATH` runtime][LD_LIBRARY_PATH runtime].
+They can also be switched to run in an environment referred to as
+`Legacy runtime 1.0`, which is the Steam Runtime 1 'scout' `LD_LIBRARY_PATH`
+runtime used on its own.
+To target either of these environments,
+developers should compile their games in the [scout SDK][].
+For backwards compatibility,
+this is still the default when a developer publishes a native Linux game,
+but we now recommend that developers should target sniper instead.
 
 The Steam Runtime is also used by the [Proton][] Steam Play compatibility
 tools, which run Windows games on Linux systems.
@@ -46,6 +68,10 @@ More information about the
 [LD_LIBRARY_PATH runtime]: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/ld-library-path-runtime.md
 [container runtime]: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/container-runtime.md
 [Proton]: https://github.com/ValveSoftware/Proton/
+[scout SDK]: https://gitlab.steamos.cloud/steamrt/scout/sdk
+[sniper]: https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/sniper/README.md
+[sniper SDK]: https://gitlab.steamos.cloud/steamrt/sniper/sdk
+[soldier]: https://gitlab.steamos.cloud/steamrt/steamrt/-/blob/steamrt/soldier/README.md
 [steam-runtime-tools documentation]: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/tree/main/docs
 
 Reporting bugs and issues

--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ They can also be downloaded by opening `steam://` links with Steam:
 
 All the software that makes up the Steam Runtime is available in both source and binary form in the Steam Runtime repository [https://repo.steampowered.com/steamrt](https://repo.steampowered.com/steamrt "")
 
-Included in this repository are scripts for building local copies of the Steam Runtime for testing and scripts for building Linux chroot environments suitable for building applications.
-
 [Steam Client for Linux]: https://github.com/ValveSoftware/steam-for-linux/
 
 Building in the runtime
@@ -183,3 +181,25 @@ These apt repositories are preconfigured in the SDK container images.
 
 A beta branch is also available for each suite.
 Please see the corresponding SDK documentation for more details.
+
+Code in this repository
+-----------------------
+
+This repository contains scripts for building local copies of the
+`LD_LIBRARY_PATH` Steam Runtime for testing.
+This is not usually necessary: using the official runtime is normally
+more appropriate.
+
+This repository also contains scripts for building Linux chroot
+environments suitable for building applications.
+These scripts are deprecated,
+and are not usually necessary.
+Using the official container-based SDKs (see above) is recommended.
+
+The container runtimes and the official container-based SDKs are not
+built using the scripts in this repository:
+instead,
+they are built using
+[flatdeb-steam](https://gitlab.steamos.cloud/steamrt/flatdeb-steam).
+It is not usually necessary for individual developers to rebuild these.
+Using the official container-based SDKs (see above) is recommended.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-steam runtime SDK
-=================
+Steam Runtime
+=============
 
 A binary compatible runtime environment for Steam applications on Linux.
 
@@ -95,24 +95,26 @@ Building in the runtime
 -----------------------
 
 To prevent libraries from development and build machines 'leaking'
-into your applications, you should build within a Steam Runtime container
-or chroot environment.
+into your applications, you should build within a Steam Runtime container.
 
 We recommend using a
 [Toolbx](https://containertoolbx.org/),
 [rootless Podman](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md)
 or [Docker](https://docs.docker.com/get-docker/)
-container for this:
+container for this.
+All of these environments are compatible with the official Steam Runtime
+SDK images,
+which we provide in OCI format.
 
-    podman pull registry.gitlab.steamos.cloud/steamrt/scout/sdk
+If targeting Steam Linux Runtime 3.0 'sniper',
+please consult the
+[Steam Runtime 3 'sniper' SDK](https://gitlab.steamos.cloud/steamrt/sniper/sdk/-/blob/steamrt/sniper/README.md)
+documentation for details.
 
-or
-
-    sudo docker pull registry.gitlab.steamos.cloud/steamrt/scout/sdk
-
-For more details, please consult the
-[Steam Runtime SDK](https://gitlab.steamos.cloud/steamrt/scout/sdk/-/blob/steamrt/scout/README.md)
-documentation.
+If targeting the legacy 'scout' runtime,
+please consult the
+[Steam Runtime 1 'scout' SDK](https://gitlab.steamos.cloud/steamrt/scout/sdk/-/blob/steamrt/scout/README.md)
+documentation instead.
 
 ### Using a debugger in the build environment
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Introduction
 
 The Linux version of Steam runs on many Linux distributions, ranging
 from the latest rolling-release distributions like Arch Linux to older
-LTS distributions like Ubuntu 14.04.
+LTS distributions like Ubuntu 16.04.
 To achieve this, it uses a special library stack, the *Steam Runtime*,
 which is installed in `~/.steam/root/ubuntu12_32/steam-runtime`.
 This is Steam Runtime version 1, codenamed `scout` after the Team

--- a/README.md
+++ b/README.md
@@ -90,12 +90,6 @@ on resolving issues.
 [known issues]: doc/steamlinuxruntime-known-issues.md
 [reporting bugs]: doc/reporting-steamlinuxruntime-bugs.md
 
-Steam-runtime Repository
-------------------------
-
-The Steam-runtime SDK relies on an APT repository that Valve has created that holds the packages contained within the steam-runtime. A single package, steamrt-dev, lists all the steam-runtime development packages (i.e. packages that contain headers and files required to build software with those libraries, and whose names end in -dev) as dependencies. Conceptually, a base chroot environment is created in the traditional way using debootstrap, steamrt-dev is then installed into this, and then a set of commonly used compilers and build tools are installed. It is expected that after this script sets the environment up, developers may want to install other packages / tools they may need into the chroot environment.
-If any of these packages contain runtime dependencies, then you will have to make sure to satisfy these yourself, as only the runtime dependencies of the steamrt-dev packages are included in the steam-runtime. 
-
 Installation
 ------------
 
@@ -175,3 +169,17 @@ Using detached debug symbols
 ----------------------------
 
 Please see [doc/debug-symbols.md](doc/debug-symbols.md).
+
+Steam Runtime apt repositories
+------------------------------
+
+Each Steam Runtime suite has an associated apt repository:
+
+* [`deb https://repo.steampowered.com/steamrt3/apt sniper main contrib non-free`](https://repo.steampowered.com/steamrt3/apt)
+* [`deb https://repo.steampowered.com/steamrt2/apt soldier main contrib non-free`](https://repo.steampowered.com/steamrt2/apt)
+* [`deb https://repo.steampowered.com/steamrt1/apt scout main`](https://repo.steampowered.com/steamrt1/apt)
+
+These apt repositories are preconfigured in the SDK container images.
+
+A beta branch is also available for each suite.
+Please see the corresponding SDK documentation for more details.

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -287,6 +287,11 @@ def parse_args():
 	if not args.architectures:
 		args.architectures = list(DEFAULT_ARCHITECTURES)
 
+	if args.suite not in ('scout', 'scout_beta'):
+		parser.error(
+			'This script is only used for the scout LD_LIBRARY_PATH runtime'
+		)
+
 	if not args.packages_from and not args.metapackages:
 		args.metapackages = ['steamrt-ld-library-path', 'steamrt-libs']
 

--- a/build-runtime.py
+++ b/build-runtime.py
@@ -285,10 +285,7 @@ def parse_args():
 			% args.output)
 
 	if not args.architectures:
-		if args.suite in ('heavy', 'heavy_beta'):
-			args.architectures = ['amd64']
-		else:
-			args.architectures = list(DEFAULT_ARCHITECTURES)
+		args.architectures = list(DEFAULT_ARCHITECTURES)
 
 	if not args.packages_from and not args.metapackages:
 		args.metapackages = ['steamrt-ld-library-path', 'steamrt-libs']
@@ -1287,12 +1284,6 @@ apt_sources = [
 ]
 seen_apt_lines = set()		# type: typing.Set[str]
 
-if args.suite in ('heavy', 'heavy_beta') and not args.upstream_apt_sources:
-	args.upstream_apt_sources = [
-		'both https://deb.debian.org/debian jessie main',
-		'both https://deb.debian.org/debian-security jessie/updates main',
-	]
-
 for line in list(args.upstream_apt_sources) + list(args.extra_apt_sources):
 	if line in seen_apt_lines:
 		continue
@@ -1417,8 +1408,6 @@ with open(os.path.join(args.output, 'version.txt'), 'w') as writer:
 if args.debug_url is None:
 	if args.suite in ('scout', 'scout_beta'):
 		args.debug_url = 'https://repo.steampowered.com/steamrt-images-scout/snapshots/'
-	elif args.suite in ('heavy', 'heavy_beta'):
-		args.debug_url = 'https://repo.steampowered.com/steamrt-images-heavy/snapshots/'
 
 if args.debug_url:
 	# Note where people can get the debug version of this runtime


### PR DESCRIPTION
* README: Ubuntu 14.04 no longer works, mention 16.04 instead
    
    Ubuntu 16.04 is the minimum version since steam-launcher 1.0.0.76.

* README: Link to Steam Runtime SDK docs instead of repeating ourselves
    
    Adding and updating detailed documentation in this repository is
    inconvenient, because for historical reasons its git history contains
    large binaries, which cannot be removed without invalidating branches
    and forks of the repository.
    
    Each branch of the Steam Runtime has its own SDK hosted elsewhere,
    so link to those as the primary thing to use.

* README: Mention Distrobox as an alternative to Toolbx
    
    Either one should usually work equally well.
    
    Resolves: https://github.com/ValveSoftware/steam-runtime/issues/739

* Update introduction to reflect reality as of early 2025
    
    - Native sniper games are now recommended
    - Legacy scout games now run in SLR 1.0 by default
    - Legacy scout games can be told to run in the legacy LDLP runtime

* Update introduction to reflect Proton status in early 2025
    
    We never updated this when Proton 8 switched to sniper. Do so now.

* README: De-emphasize the apt repositories
    
    The official SDK container images are normally preferable to accessing
    the apt repositories directly, and they contain the apt repositories
    as preconfigured apt sources.

* README: De-emphasize the scripts in this repository
    
    Some of the scripts in this repository are still necessary when used
    internally (in particular, we still use `build-runtime.py` to build
    official scout releases), but third-party developers shouldn't normally
    need to run them, and they are not the same scripts that we use to build
    the container-based runtimes.
    
    Resolves: https://github.com/ValveSoftware/steam-runtime/issues/737

* build-runtime.py: Remove references to heavy
    
    We no longer build or use Steam Runtime 1½ 'heavy'.

* build-runtime: Make it clearer that this is not used for sniper, etc.
    
    Resolves: https://github.com/ValveSoftware/steam-runtime/issues/737

---

HTML preview: https://github.com/smcv/steam-runtime/blob/wip/only-scout/README.md