### PR TITLE
doc: Recommend setting only `STEAM_RUNTIME_SCOUT`

### DIFF
--- a/doc/building-custom-runtime.md
+++ b/doc/building-custom-runtime.md
@@ -74,9 +74,9 @@ what appears in Help -> System Information in Steam, if your runtime is in
     ~/rttest/run.sh ~/rttest/usr/bin/steam-runtime-system-info
 
 Or to launch Steam itself (and any Steam applications) within your runtime,
-set both the `STEAM_RUNTIME_SCOUT` and `STEAM_RUNTIME` environment variables
-to point to your runtime directory:
+set the `STEAM_RUNTIME_SCOUT` environment variable to point to your
+runtime directory:
 
-    $ STEAM_RUNTIME_SCOUT=~/rttest STEAM_RUNTIME="$STEAM_RUNTIME_SCOUT" ./steam.sh
+    $ STEAM_RUNTIME_SCOUT=~/rttest ./steam.sh
     Running Steam on ubuntu 14.04 64-bit
     STEAM_RUNTIME has been set by the user to: /home/username/rttest


### PR DESCRIPTION
Before 2024, `STEAM_RUNTIME` was both an input from the user (telling `steam.sh` which runtime they wanted to use), and an output from `run.sh` (telling code inside the runtime environment which runtime it was using).

In current versions of Steam, the input from the user is only `STEAM_RUNTIME_SCOUT`, and the output from `run.sh` is only `STEAM_RUNTIME`.

Followup for commit 881ddce6 "doc: Set both STEAM_RUNTIME_SCOUT and STEAM_RUNTIME for custom runtimes".

---

Documentation fix only, no functional impact.

cc @TTimo 